### PR TITLE
Make aiodns an extra

### DIFF
--- a/biolmai/__init__.py
+++ b/biolmai/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for BioLM AI."""
 __author__ = """Nikhil Haas"""
 __email__ = "nikhil@biolm.ai"
-__version__ = '0.1.9'
+__version__ = '0.1.10'
 
 from biolmai.cls import *
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,7 +60,7 @@ author = "Nikhil Haas"
 # the built documents.
 #
 # The short X.Y version.
-version = '0.1.9'
+version = '0.1.10'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.9
+current_version = 0.1.10
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as readme_file:
 with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = ["Click>=6.0", "requests", "pandas", "aiohttp", "aiodns"]
+requirements = ["Click>=6.0", "requests", "pandas", "aiohttp"]
 
 test_requirements = [
     "pytest>=3",
@@ -37,6 +37,9 @@ setup(
         "console_scripts": [
             "biolmai=biolmai.cli:cli",
         ],
+    },
+    extras_require={
+        "aiodns": ["aiodns"]
     },
     install_requires=requirements,
     license="Apache Software License 2.0",

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/BioLM/py-biolm",
-    version='0.1.9',
+    version='0.1.10',
     zip_safe=False,
 )


### PR DESCRIPTION
It's not a pure-Python package, so can't micropip install biolmai with aiodns. Make it an extra.