### PR TITLE
Add ability to read/write from existing output files

### DIFF
--- a/biolmai/__init__.py
+++ b/biolmai/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for BioLM AI."""
 __author__ = """Nikhil Haas"""
 __email__ = "nikhil@biolm.ai"
-__version__ = '0.2.7'
+__version__ = '0.2.8'
 
 from biolmai.client import BioLMApi, BioLMApiClient
 from biolmai.biolmai import BioLM

--- a/biolmai/biolmai.py
+++ b/biolmai/biolmai.py
@@ -81,6 +81,7 @@ class BioLM:
             stop_on_error=self._class_kwargs.pop('stop_on_error', None),
             output=self._class_kwargs.pop('output', None),
             file_path=self._class_kwargs.pop('file_path', None),
+            overwrite=self._class_kwargs.pop('overwrite', None),
         ).items() if v is not None}
 
         model = BioLMApi(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ author = "Nikhil Haas"
 # the built documents.
 #
 # The short X.Y version.
-version = '0.2.7'
+version = '0.2.8'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 [project]
 name = "biolmai"
-version = "0.2.7"
+version = "0.2.8"
 description = "BioLM Python client"
 authors = [
     { name="BioLM", email="support@biolm.ai" }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.7
+current_version = 0.2.8
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/BioLM/py-biolm",
-    version='0.2.7',
+    version='0.2.8',
     zip_safe=False,
 )

--- a/tests/test_aclient.py
+++ b/tests/test_aclient.py
@@ -1,12 +1,11 @@
 import json
 import logging
 
-from biolmai.client import BioLMApi
+import aiofiles
+import pytest
+from biolmai.client import BioLMApi, BioLMApiClient
 
 LOGGER = logging.getLogger(__name__)
-
-import pytest
-from biolmai.client import BioLMApiClient
 
 @pytest.fixture(scope='function')
 def model():
@@ -220,5 +219,78 @@ async def test_invalid_input_items_type(model, monkeypatch):
     monkeypatch.setattr(model, "_batch_call_autoschema_or_manual", lambda *a, **kw: None)
     with pytest.raises(TypeError, match="Parameter 'items' must be of type list, tuple"):
         await model.predict(items={"sequence": "MDNELE"})
+
+
+@pytest.mark.asyncio
+async def test_disk_output_skip_existing_file_async(tmp_path):
+    """Test async client: when file exists and overwrite=False, it skips API call and returns existing file contents."""
+    model = BioLMApiClient("esmfold", raise_httpx=False)
+    file_path = tmp_path / "existing.jsonl"
+    items = [{"sequence": "MDNELE"}]
+    
+    # First, write some data to the file
+    initial_data = {"mean_plddt": 95.5, "pdb": "ATOM 1 N MET", "test": "initial"}
+    async with aiofiles.open(file_path, 'w') as f:
+        await f.write(json.dumps(initial_data) + '\n')
+    
+    # Verify file exists
+    assert file_path.exists()
+    
+    # Call with overwrite=False (default) - should skip API call and return existing data
+    result = await model.predict(items=items, output='disk', file_path=str(file_path), overwrite=False)
+    
+    # Should return the existing file contents
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["test"] == "initial"
+    assert result[0]["mean_plddt"] == 95.5
+    
+    # Verify file was not overwritten (still has initial data)
+    async with aiofiles.open(file_path, 'r') as f:
+        content = await f.read()
+    lines = content.splitlines()
+    assert len(lines) == 1
+    file_data = json.loads(lines[0])
+    assert file_data["test"] == "initial"
+
+
+@pytest.mark.asyncio
+async def test_disk_output_overwrite_existing_file_async(tmp_path):
+    """Test async client: when overwrite=True, it makes API call and overwrites existing file."""
+    model = BioLMApiClient("esmfold", raise_httpx=False)
+    file_path = tmp_path / "existing.jsonl"
+    items = [{"sequence": "MDNELE"}]
+    
+    # First, write some initial data to the file
+    initial_data = {"mean_plddt": 0.0, "pdb": "OLD DATA", "test": "should_be_overwritten"}
+    async with aiofiles.open(file_path, 'w') as f:
+        await f.write(json.dumps(initial_data) + '\n')
+    
+    # Verify file exists and has initial data
+    assert file_path.exists()
+    async with aiofiles.open(file_path, 'r') as f:
+        content = await f.read()
+    initial_lines = content.splitlines()
+    assert len(initial_lines) == 1
+    assert json.loads(initial_lines[0])["test"] == "should_be_overwritten"
+    
+    # Call with overwrite=True - should make API call and overwrite file
+    result = await model.predict(items=items, output='disk', file_path=str(file_path), overwrite=True)
+    
+    # When output='disk' and overwrite=True, result should be None (file is written, nothing returned)
+    assert result is None
+    
+    # Verify file was overwritten with new API response
+    async with aiofiles.open(file_path, 'r') as f:
+        content = await f.read()
+    lines = content.splitlines()
+    assert len(lines) == 1
+    file_data = json.loads(lines[0])
+    # Should have new data from API (not the initial test data)
+    assert "test" not in file_data  # The test key should not be in API response
+    assert "mean_plddt" in file_data
+    assert "pdb" in file_data
+    # Verify it's actually different from initial data
+    assert file_data["mean_plddt"] != 0.0 or file_data["pdb"] != "OLD DATA"
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -216,3 +216,164 @@ def test_invalid_input_items_type(model, monkeypatch):
     # Should raise TypeError because items is not a list/tuple
     with pytest.raises(TypeError, match="Parameter 'items' must be of type list, tuple"):
         model.predict(items={"sequence": "MDNELE"})
+
+
+def test_disk_output_skip_existing_file(tmp_path, model):
+    """Test that when file exists and overwrite=False, it skips API call and returns existing file contents."""
+    file_path = tmp_path / "existing.jsonl"
+    items = [{"sequence": "MDNELE"}]
+    
+    # First, write some data to the file
+    initial_data = {"mean_plddt": 95.5, "pdb": "ATOM 1 N MET", "test": "initial"}
+    with open(file_path, 'w') as f:
+        f.write(json.dumps(initial_data) + '\n')
+    
+    # Verify file exists
+    assert file_path.exists()
+    
+    # Call with overwrite=False (default) - should skip API call and return existing data
+    result = model.predict(items=items, output='disk', file_path=str(file_path), overwrite=False)
+    
+    # Should return the existing file contents
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["test"] == "initial"
+    assert result[0]["mean_plddt"] == 95.5
+    
+    # Verify file was not overwritten (still has initial data)
+    lines = file_path.read_text().splitlines()
+    assert len(lines) == 1
+    file_data = json.loads(lines[0])
+    assert file_data["test"] == "initial"
+
+
+def test_disk_output_overwrite_existing_file(tmp_path, model):
+    """Test that when overwrite=True, it makes API call and overwrites existing file."""
+    file_path = tmp_path / "existing.jsonl"
+    items = [{"sequence": "MDNELE"}]
+    
+    # First, write some initial data to the file
+    initial_data = {"mean_plddt": 0.0, "pdb": "OLD DATA", "test": "should_be_overwritten"}
+    with open(file_path, 'w') as f:
+        f.write(json.dumps(initial_data) + '\n')
+    
+    # Verify file exists and has initial data
+    assert file_path.exists()
+    initial_lines = file_path.read_text().splitlines()
+    assert len(initial_lines) == 1
+    assert json.loads(initial_lines[0])["test"] == "should_be_overwritten"
+    
+    # Call with overwrite=True - should make API call and overwrite file
+    result = model.predict(items=items, output='disk', file_path=str(file_path), overwrite=True)
+    
+    # When output='disk' and overwrite=True, result should be None (file is written, nothing returned)
+    assert result is None
+    
+    # Verify file was overwritten with new API response
+    lines = file_path.read_text().splitlines()
+    assert len(lines) == 1
+    file_data = json.loads(lines[0])
+    # Should have new data from API (not the initial test data)
+    assert "test" not in file_data  # The test key should not be in API response
+    assert "mean_plddt" in file_data
+    assert "pdb" in file_data
+    # Verify it's actually different from initial data
+    assert file_data["mean_plddt"] != 0.0 or file_data["pdb"] != "OLD DATA"
+
+
+def test_disk_output_skip_empty_file(tmp_path, model):
+    """Test that when file exists but is empty, it returns empty list and skips API call."""
+    file_path = tmp_path / "empty.jsonl"
+    items = [{"sequence": "MDNELE"}]
+    
+    # Create empty file
+    file_path.touch()
+    assert file_path.exists()
+    assert file_path.stat().st_size == 0
+    
+    # Call with overwrite=False - should skip API call and return empty list
+    result = model.predict(items=items, output='disk', file_path=str(file_path), overwrite=False)
+    
+    # Should return empty list (no valid JSON lines)
+    assert isinstance(result, list)
+    assert len(result) == 0
+    
+    # Verify file was not modified (still empty)
+    assert file_path.stat().st_size == 0
+
+
+def test_disk_output_skip_file_with_invalid_json(tmp_path, model):
+    """Test that when file exists with invalid JSON, it skips invalid lines and returns valid ones."""
+    file_path = tmp_path / "mixed.jsonl"
+    items = [{"sequence": "MDNELE"}]
+    
+    # Write file with mix of valid and invalid JSON
+    with open(file_path, 'w') as f:
+        f.write('{"valid": "data1"}\n')
+        f.write('invalid json line\n')
+        f.write('{"valid": "data2"}\n')
+        f.write('{"incomplete": \n')  # Invalid JSON
+        f.write('{"valid": "data3"}\n')
+    
+    # Call with overwrite=False - should skip API call and return valid JSON lines
+    result = model.predict(items=items, output='disk', file_path=str(file_path), overwrite=False)
+    
+    # Should return only valid JSON lines
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert result[0]["valid"] == "data1"
+    assert result[1]["valid"] == "data2"
+    assert result[2]["valid"] == "data3"
+    
+    # Verify file was not modified
+    lines = file_path.read_text().splitlines()
+    assert len(lines) == 5  # Original 5 lines still there
+
+
+def test_disk_output_skip_biolm_wrapper(tmp_path):
+    """Test that BioLM high-level wrapper also respects overwrite parameter."""
+    from biolmai.biolmai import BioLM
+    file_path = tmp_path / "biolm_wrapper.jsonl"
+    
+    # First, write some data to the file
+    initial_data = {"mean_plddt": 95.5, "pdb": "ATOM 1 N MET", "test": "initial"}
+    with open(file_path, 'w') as f:
+        f.write(json.dumps(initial_data) + '\n')
+    
+    # Call with overwrite=False - should skip API call and return existing data
+    result = BioLM(
+        entity="esmfold",
+        action="predict",
+        type="sequence",
+        items="MDNELE",
+        output='disk',
+        file_path=str(file_path),
+        overwrite=False
+    )
+    
+    # Should return the existing file contents
+    assert isinstance(result, dict)  # BioLM unwraps single results by default
+    assert result["test"] == "initial"
+    assert result["mean_plddt"] == 95.5
+
+
+def test_disk_output_skip_list_of_lists(tmp_path, model):
+    """Test that overwrite=False works correctly with list of lists (pre-batched items)."""
+    file_path = tmp_path / "lol.jsonl"
+    
+    # First, write some data to the file (simulating results from list of lists)
+    with open(file_path, 'w') as f:
+        f.write(json.dumps({"batch1": "result1"}) + '\n')
+        f.write(json.dumps({"batch1": "result2"}) + '\n')
+        f.write(json.dumps({"batch2": "result3"}) + '\n')
+    
+    # Call with overwrite=False and list of lists
+    items = [[{"sequence": "MDNELE"}], [{"sequence": "MENDEL"}], [{"sequence": "ISOTYPE"}]]
+    result = model.predict(items=items, output='disk', file_path=str(file_path), overwrite=False)
+    
+    # Should return the existing file contents
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert result[0]["batch1"] == "result1"
+    assert result[1]["batch1"] == "result2"
+    assert result[2]["batch2"] == "result3"


### PR DESCRIPTION
Can overwrite the file, or skip API requests if it exists already