### PR TITLE
Loosen requirement for generate to return same N items posted

### DIFF
--- a/biolmai/api.py
+++ b/biolmai/api.py
@@ -188,7 +188,9 @@ class APIEndpoint:
                 batch_res = pd.DataFrame({"api_resp": api_resps})
                 len_res = batch_res.shape[0]
             orig_request_rows = keep_batches.shape[0]
-            if len_res != orig_request_rows:
+            # For 'generate' actions, models may return multiple results per item
+            # (e.g., hyper-mpnn with batch_size > 1), so skip the 1:1 check
+            if action != "generate" and len_res != orig_request_rows:
                 err = "Response rows ({}) mismatch with input rows ({})"
                 err = err.format(len_res, orig_request_rows)
                 raise AssertionError(err)

--- a/biolmai/client.py
+++ b/biolmai/client.py
@@ -509,10 +509,13 @@ class BioLMApiClient:
                             batch_results = await retry_batch_individually(batch)
 
                         if isinstance(batch_results, list):
-                            assert len(batch_results) == len(batch), (
-                                f"API returned {len(batch_results)} results for a batch of {len(batch)} items. "
-                                "This is a contract violation."
-                            )
+                            # For 'generate' actions, models may return multiple results per item
+                            # (e.g., hyper-mpnn with batch_size > 1), so skip the 1:1 check
+                            if func != "generate":
+                                assert len(batch_results) == len(batch), (
+                                    f"API returned {len(batch_results)} results for a batch of {len(batch)} items. "
+                                    "This is a contract violation."
+                                )
                             for res in batch_results:
                                 await file_handle.write(json.dumps(res) + '\n')
                         else:
@@ -540,10 +543,13 @@ class BioLMApiClient:
                         if stop_on_error:
                             break
                     elif isinstance(batch_results, list):
-                        assert len(batch_results) == len(batch), (
-                            f"API returned {len(batch_results)} results for a batch of {len(batch)} items. "
-                            "This is a contract violation."
-                        )
+                        # For 'generate' actions, models may return multiple results per item
+                        # (e.g., hyper-mpnn with batch_size > 1), so skip the 1:1 check
+                        if func != "generate":
+                            assert len(batch_results) == len(batch), (
+                                f"API returned {len(batch_results)} results for a batch of {len(batch)} items. "
+                                "This is a contract violation."
+                            )
                         results.extend(batch_results)
                         if stop_on_error and all(isinstance(r, dict) and ('error' in r or 'status_code' in r) for r in batch_results):
                             break
@@ -584,10 +590,13 @@ class BioLMApiClient:
                     else:
                         if not isinstance(batch_results, list):
                             batch_results = [batch_results]
-                        assert len(batch_results) == len(batch), (
-                            f"API returned {len(batch_results)} results for a batch of {len(batch)} items. "
-                            "This is a contract violation."
-                        )
+                        # For 'generate' actions, models may return multiple results per item
+                        # (e.g., hyper-mpnn with batch_size > 1), so skip the 1:1 check
+                        if func != "generate":
+                            assert len(batch_results) == len(batch), (
+                                f"API returned {len(batch_results)} results for a batch of {len(batch)} items. "
+                                "This is a contract violation."
+                            )
                         for res in batch_results:
                             to_dump = res[0] if (raw and isinstance(res, tuple)) else res
                             await file_handle.write(json.dumps(to_dump) + '\n')
@@ -619,10 +628,13 @@ class BioLMApiClient:
                 else:
                     if not isinstance(batch_results, list):
                         batch_results = [batch_results]
-                    assert len(batch_results) == len(batch), (
-                        f"API returned {len(batch_results)} results for a batch of {len(batch)} items. "
-                        "This is a contract violation."
-                    )
+                    # For 'generate' actions, models may return multiple results per item
+                    # (e.g., hyper-mpnn with batch_size > 1), so skip the 1:1 check
+                    if func != "generate":
+                        assert len(batch_results) == len(batch), (
+                            f"API returned {len(batch_results)} results for a batch of {len(batch)} items. "
+                            "This is a contract violation."
+                        )
                     results.extend(batch_results)
                     if stop_on_error and all(isinstance(r, dict) and ('error' in r or 'status_code' in r) for r in batch_results):
                         break


### PR DESCRIPTION
Models like MPNN can return multiple per 'item' POSTed. Currently our client throws an error because number of 'items' returned doesn't match the number POSTed.