### PR TITLE
feat: ProtocolClient — programmatic protocol submission, progress polling, and results download

### DIFF
--- a/biolmai/__init__.py
+++ b/biolmai/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for BioLM AI."""
 __author__ = """Nikhil Haas"""
 __email__ = "nikhil@biolm.ai"
-__version__ = '0.5.0'
+__version__ = '0.4.1'
 
 from biolmai.core.http import BioLMApi, BioLMApiClient
 from biolmai.biolmai import BioLM

--- a/biolmai/__init__.py
+++ b/biolmai/__init__.py
@@ -80,7 +80,6 @@ def run_protocol(
     run_name: Optional[str] = None,
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
-    poll_interval: float = 5.0,
     timeout: float = 3600.0,
     show_progress: bool = True,
 ) -> dict:
@@ -95,7 +94,6 @@ def run_protocol(
         run_name: Optional human-readable label.
         api_key: BioLM API token. Reads ``BIOLMAI_TOKEN`` env var if not provided.
         base_url: Override API base domain (default ``https://biolm.ai``).
-        poll_interval: Seconds between progress polls (default 5).
         timeout: Max seconds to wait before raising :class:`TimeoutError` (default 3600).
         show_progress: Print progress updates to stdout (default True).
 
@@ -121,7 +119,6 @@ def run_protocol(
         slug,
         inputs,
         run_name=run_name,
-        poll_interval=poll_interval,
         timeout=timeout,
         show_progress=show_progress,
     )

--- a/biolmai/__init__.py
+++ b/biolmai/__init__.py
@@ -8,6 +8,7 @@ from biolmai.biolmai import BioLM
 from biolmai.models import Model, predict, encode, generate
 from biolmai.protocols import Protocol
 from biolmai.finetune import Finetune
+from biolmai.protocol_runs import ProtocolClient, ProtocolRun, ProtocolRunError, ProtocolNotFoundError
 from biolmai.workspaces import Workspace
 from biolmai.volumes import Volume
 from biolmai.examples import get_example, list_models
@@ -45,6 +46,12 @@ __all__ = [
     'Finetune',
     'Workspace',
     'Volume',
+    # Protocol Submission API
+    'ProtocolClient',
+    'ProtocolRun',
+    'ProtocolRunError',
+    'ProtocolNotFoundError',
+    'run_protocol',
     # Convenience functions
     'predict',
     'encode',
@@ -64,6 +71,60 @@ __all__ = [
 ]
 if _HAS_PIPELINE:
     __all__.append('pipeline')
+
+
+def run_protocol(
+    slug: str,
+    inputs: dict,
+    *,
+    run_name: Optional[str] = None,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    poll_interval: float = 5.0,
+    timeout: float = 3600.0,
+    show_progress: bool = True,
+) -> dict:
+    """Submit a BioLM protocol run and block until results are ready.
+
+    One-liner convenience wrapper around :class:`ProtocolClient`.
+
+    Args:
+        slug: Protocol slug (e.g. ``"antibody-optimization"``).
+        inputs: Dict of input field values. Use
+            ``ProtocolClient().get(slug)["inputs_schema"]`` to discover required fields.
+        run_name: Optional human-readable label.
+        api_key: BioLM API token. Reads ``BIOLMAI_TOKEN`` env var if not provided.
+        base_url: Override API base domain (default ``https://biolm.ai``).
+        poll_interval: Seconds between progress polls (default 5).
+        timeout: Max seconds to wait before raising :class:`TimeoutError` (default 3600).
+        show_progress: Print progress updates to stdout (default True).
+
+    Returns:
+        The results payload (``return_json``) from the completed run.
+
+    Raises:
+        :class:`ProtocolRunError`: If the run fails or is cancelled.
+        :class:`TimeoutError`: If ``timeout`` is exceeded.
+
+    Example::
+
+        import biolmai
+
+        results = biolmai.run_protocol(
+            "antibody-optimization",
+            inputs={"sequence": "MKTAYIAKQRQ", "n_rounds": 3},
+        )
+        print(results["designed_sequences"])
+    """
+    client = ProtocolClient(api_key=api_key, base_url=base_url)
+    return client.run_and_wait(
+        slug,
+        inputs,
+        run_name=run_name,
+        poll_interval=poll_interval,
+        timeout=timeout,
+        show_progress=show_progress,
+    )
 
 
 def biolm(

--- a/biolmai/__init__.py
+++ b/biolmai/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for BioLM AI."""
 __author__ = """Nikhil Haas"""
 __email__ = "nikhil@biolm.ai"
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 from biolmai.core.http import BioLMApi, BioLMApiClient
 from biolmai.biolmai import BioLM

--- a/biolmai/protocol_runs.py
+++ b/biolmai/protocol_runs.py
@@ -97,6 +97,7 @@ class ProtocolRun:
         self.protocol_version: int = data.get("protocol_version", 1)
         self.status: str = data.get("status", "scheduled")
         self._client = client
+        self._failure_error: Optional[str] = None
 
     def __repr__(self) -> str:
         return (
@@ -140,15 +141,12 @@ class ProtocolRun:
 
     def wait(
         self,
-        poll_interval: float = 5.0,
         timeout: float = 3600.0,
         show_progress: bool = True,
     ) -> "ProtocolRun":
         """Block until this run reaches a terminal state.
 
         Args:
-            poll_interval: Unused — progress is tracked via WebSocket. Kept for
-                backwards-compatibility. Default ``5``.
             timeout: Maximum seconds to wait before raising
                 :class:`TimeoutError`. Default ``3600`` (1 hour).
             show_progress: Print progress lines to stdout. Default ``True``.
@@ -163,7 +161,7 @@ class ProtocolRun:
         Example::
 
             run = client.submit("my-protocol", inputs={"sequence": "MKLL..."})
-            run.wait(poll_interval=10, timeout=7200)
+            run.wait(timeout=7200)
             print(run.results())
         """
         # Fetch channel_id for this run (single HTTP call — not a poll loop)
@@ -179,8 +177,9 @@ class ProtocolRun:
             self._check_terminal()
             return self
 
+        _ws_scheme = "wss" if self._client._base.startswith("https://") else "ws"
         domain = self._client._base.replace("https://", "").replace("http://", "").split("/")[0]
-        ws_url = f"wss://{domain}/ws/telemetry/{channel_id}/"
+        ws_url = f"{_ws_scheme}://{domain}/ws/telemetry/{channel_id}/"
 
         self._listen_ws(ws_url, show_progress=show_progress, timeout=timeout)
 
@@ -219,8 +218,11 @@ class ProtocolRun:
                     payload = env.get("payload", env)
                     status = payload.get("status") or env.get("status")
                     pct = payload.get("progress_pct") or env.get("progress_pct")
+                    error = payload.get("failure_error") or env.get("failure_error")
                     if status:
                         self.status = status
+                    if error:
+                        self._failure_error = error
                     if show_progress:
                         pct_str = f" {pct}%" if pct is not None else ""
                         print(f"  [{self.run_id}] {self.status}{pct_str}")
@@ -259,10 +261,12 @@ class ProtocolRun:
     def _check_terminal(self) -> None:
         """Raise if status is failed or cancelled."""
         if self.status == "failed":
-            try:
-                detail = self._client._get(f"runs/{self.run_id}/").get("failure_error") or "unknown error"
-            except Exception:
-                detail = "unknown error"
+            detail = self._failure_error
+            if not detail:
+                try:
+                    detail = self._client._get(f"runs/{self.run_id}/").get("failure_error") or "unknown error"
+                except Exception:
+                    detail = "unknown error"
             raise ProtocolRunError(f"Protocol run {self.run_id} failed: {detail}")
         if self.status == "cancelled":
             raise ProtocolRunError(f"Protocol run {self.run_id} was cancelled.")
@@ -322,6 +326,12 @@ class ProtocolRun:
             path = run.download(output_dir="./results")
             # path → PosixPath('./results/ALY_xxx_results.csv.zip')
         """
+        _VALID_FILE_TYPES = {"csv", "jsonl"}
+        if file_type not in _VALID_FILE_TYPES:
+            raise ValueError(
+                f"file_type must be one of {sorted(_VALID_FILE_TYPES)}, got {file_type!r}."
+            )
+
         out = Path(output_dir)
         out.mkdir(parents=True, exist_ok=True)
         dest = out / f"{self.run_id}_results.{file_type}.zip"
@@ -751,7 +761,6 @@ class ProtocolClient:
         slug: str,
         inputs: Dict[str, Any],
         run_name: Optional[str] = None,
-        poll_interval: float = 5.0,
         timeout: float = 3600.0,
         show_progress: bool = True,
     ) -> Dict[str, Any]:
@@ -764,7 +773,6 @@ class ProtocolClient:
             slug: Protocol slug.
             inputs: Input field values.
             run_name: Optional run label.
-            poll_interval: Seconds between polls (default 5).
             timeout: Max seconds to wait (default 3600).
             show_progress: Print progress updates (default True).
 
@@ -785,5 +793,5 @@ class ProtocolClient:
         run = self.submit(slug, inputs, run_name=run_name)
         if show_progress:
             print(f"Submitted: {run.run_id}  [{slug}]")
-        run.wait(poll_interval=poll_interval, timeout=timeout, show_progress=show_progress)
+        run.wait(timeout=timeout, show_progress=show_progress)
         return run.results().get("results", {})

--- a/biolmai/protocol_runs.py
+++ b/biolmai/protocol_runs.py
@@ -147,7 +147,8 @@ class ProtocolRun:
         """Block until this run reaches a terminal state.
 
         Args:
-            poll_interval: Seconds between progress polls. Default ``5``.
+            poll_interval: Unused — progress is tracked via WebSocket. Kept for
+                backwards-compatibility. Default ``5``.
             timeout: Maximum seconds to wait before raising
                 :class:`TimeoutError`. Default ``3600`` (1 hour).
             show_progress: Print progress lines to stdout. Default ``True``.
@@ -226,8 +227,24 @@ class ProtocolRun:
                     if self.status in ("succeeded", "failed", "cancelled"):
                         return
 
+        # Apply nest_asyncio if called from within a running event loop (e.g. Jupyter)
         try:
-            asyncio.run(_listen())
+            asyncio.get_running_loop()
+            import nest_asyncio
+            nest_asyncio.apply()
+        except RuntimeError:
+            pass  # No running loop — asyncio.run() will work normally
+
+        try:
+            asyncio.run(asyncio.wait_for(_listen(), timeout=timeout))
+        except asyncio.TimeoutError:
+            try:
+                self.refresh()
+            except Exception:
+                pass
+            raise TimeoutError(
+                f"Protocol run {self.run_id} did not complete within {timeout:.0f}s."
+            )
         except Exception as exc:
             try:
                 self.refresh()
@@ -448,10 +465,10 @@ class ProtocolClient:
         )
         print(results)
 
-        # Submit async, then download structure files
+        # Submit async, then download results
         run = client.submit("structure-prediction", inputs={"sequence": "MKLL..."})
         run.wait()
-        run.download_files("./structures", columns=["pdb"])
+        path = run.download(output_dir="./structures")
     """
 
     def __init__(

--- a/biolmai/protocol_runs.py
+++ b/biolmai/protocol_runs.py
@@ -1,0 +1,701 @@
+"""Protocol Submission API client — programmatic run submission, progress tracking, and results retrieval.
+
+Usage::
+
+    from biolmai import ProtocolClient
+
+    client = ProtocolClient()
+
+    # Discover available protocols
+    client.list(search="antibody")
+
+    # Inspect what inputs a protocol expects before submitting
+    schema = client.get("antibody-optimization")
+    print(schema["inputs_schema"])
+
+    # Submit a run
+    run = client.submit(
+        "antibody-optimization",
+        inputs={"sequence": "MKTAYIAKQRQ", "n_rounds": 3},
+        run_name="my first run",
+    )
+
+    # Option A — block until complete
+    run.wait()
+    print(run.results())
+
+    # Option B — one-liner
+    results = client.run_and_wait("antibody-optimization", inputs={"sequence": "MKTAYIAKQRQ"})
+
+    # Download structure files after completion
+    paths = run.download_files(output_dir="./structures", columns=["designed_pdb"])
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from biolmai.core.const import BIOLMAI_BASE_DOMAIN
+
+_DEFAULT_TIMEOUT = 30
+_UPLOAD_TIMEOUT = 120
+_DOWNLOAD_TIMEOUT = 120
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def _auth_headers(api_key: Optional[str] = None) -> Dict[str, str]:
+    token = api_key or os.environ.get("BIOLMAI_TOKEN") or os.environ.get("BIOLM_TOKEN")
+    if not token:
+        raise ValueError(
+            "No API key found. Set the BIOLMAI_TOKEN environment variable or pass api_key= to ProtocolClient().\n"
+            "Get a token at https://biolm.ai/console/user/api-keys/"
+        )
+    return {"Authorization": f"Token {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class ProtocolRunError(Exception):
+    """A protocol run failed, was cancelled, or the API returned an error."""
+
+
+class ProtocolNotFoundError(ProtocolRunError):
+    """The requested protocol slug/version does not exist or is not accessible."""
+
+
+# ---------------------------------------------------------------------------
+# ProtocolRun
+# ---------------------------------------------------------------------------
+
+
+class ProtocolRun:
+    """A submitted protocol run returned by :meth:`ProtocolClient.submit`.
+
+    Attributes:
+        run_id: The ``ALY_...`` run identifier.
+        protocol_slug: The protocol slug this run belongs to.
+        protocol_version: The protocol version used.
+        status: Current status string (``scheduled`` / ``running`` / ``succeeded`` /
+            ``failed`` / ``cancelled``).
+    """
+
+    def __init__(self, data: Dict[str, Any], client: "ProtocolClient") -> None:
+        self.run_id: str = data["run_id"]
+        self.protocol_slug: str = data.get("protocol_slug", "")
+        self.protocol_version: int = data.get("protocol_version", 1)
+        self.status: str = data.get("status", "scheduled")
+        self._client = client
+
+    def __repr__(self) -> str:
+        return (
+            f"ProtocolRun(run_id={self.run_id!r}, "
+            f"slug={self.protocol_slug!r}, status={self.status!r})"
+        )
+
+    # ------------------------------------------------------------------
+    # Status & progress
+    # ------------------------------------------------------------------
+
+    def refresh(self) -> "ProtocolRun":
+        """Fetch current status from the API and update ``self.status`` in place.
+
+        Returns:
+            ``self`` for chaining.
+        """
+        data = self._client._get(f"runs/{self.run_id}/")
+        self.status = data.get("status", self.status)
+        return self
+
+    def progress(self) -> Dict[str, Any]:
+        """Return a live progress snapshot for this run.
+
+        Reads from the same event log as the browser console's live view.
+
+        Returns:
+            Dict with keys:
+
+            - ``status`` — current run status
+            - ``progress_pct`` — 0–100 integer, or ``None`` if not yet available
+            - ``tasks`` — list of per-task dicts (``name``, ``status``,
+              ``completed_subtasks``, ``total_subtasks``, ``failed_subtasks``)
+            - ``log_lines`` — last 50 log lines (newest last)
+            - ``result_row_count`` — rows emitted so far, or ``None``
+        """
+        return self._client._get(f"runs/{self.run_id}/progress/")
+
+    def log_lines(self) -> List[str]:
+        """Convenience wrapper — returns the latest log lines from :meth:`progress`."""
+        return self.progress().get("log_lines", [])
+
+    # ------------------------------------------------------------------
+    # Blocking wait
+    # ------------------------------------------------------------------
+
+    def wait(
+        self,
+        poll_interval: float = 5.0,
+        timeout: float = 3600.0,
+        show_progress: bool = True,
+    ) -> "ProtocolRun":
+        """Block until this run reaches a terminal state.
+
+        Args:
+            poll_interval: Seconds between progress polls. Default ``5``.
+            timeout: Maximum seconds to wait before raising
+                :class:`TimeoutError`. Default ``3600`` (1 hour).
+            show_progress: Print progress lines to stdout. Default ``True``.
+
+        Returns:
+            ``self`` for chaining (e.g. ``run.wait().results()``).
+
+        Raises:
+            :class:`ProtocolRunError`: If the run fails or is cancelled.
+            :class:`TimeoutError`: If ``timeout`` seconds elapse before completion.
+
+        Example::
+
+            run = client.submit("my-protocol", inputs={"sequence": "MKLL..."})
+            run.wait(poll_interval=10, timeout=7200)
+            print(run.results())
+        """
+        deadline = time.monotonic() + timeout
+        last_pct: Optional[int] = None
+
+        while True:
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"Protocol run {self.run_id} did not complete within {timeout:.0f}s. "
+                    "Increase timeout= or poll manually with run.progress()."
+                )
+
+            try:
+                snap = self.progress()
+            except Exception:
+                # Network blip — refresh plain status and retry
+                try:
+                    self.refresh()
+                except Exception:
+                    pass
+                time.sleep(poll_interval)
+                continue
+
+            self.status = snap.get("status", self.status)
+            pct: Optional[int] = snap.get("progress_pct")
+            tasks: List[Dict] = snap.get("tasks", [])
+
+            if show_progress and pct != last_pct:
+                running = [t["name"] for t in tasks if t.get("status") == "running"]
+                if pct is not None:
+                    suffix = f" — {running[0]}" if running else ""
+                    print(f"  [{self.run_id}] {pct:>3}%{suffix}")
+                elif running:
+                    print(f"  [{self.run_id}] running: {', '.join(running)}")
+                last_pct = pct
+
+            if self.status in ("succeeded", "failed", "cancelled"):
+                break
+
+            time.sleep(poll_interval)
+
+        if self.status == "failed":
+            try:
+                detail = self._client._get(f"runs/{self.run_id}/").get("failure_error") or "unknown error"
+            except Exception:
+                detail = "unknown error"
+            raise ProtocolRunError(f"Protocol run {self.run_id} failed: {detail}")
+
+        if self.status == "cancelled":
+            raise ProtocolRunError(f"Protocol run {self.run_id} was cancelled.")
+
+        if show_progress:
+            print(f"  [{self.run_id}] complete ✓")
+
+        return self
+
+    # ------------------------------------------------------------------
+    # Results
+    # ------------------------------------------------------------------
+
+    def results(self) -> Dict[str, Any]:
+        """Fetch the full run detail including the results payload.
+
+        Returns:
+            Dict with keys:
+
+            - ``run_id``, ``protocol_slug``, ``protocol_version``
+            - ``status``
+            - ``results`` — the ``return_json`` from the server (may be large)
+            - ``failure_error`` — error message if failed, else ``None``
+            - ``workflow_started_at``, ``workflow_ended_at``, ``expires_at``
+        """
+        return self._client._get(f"runs/{self.run_id}/")
+
+    # ------------------------------------------------------------------
+    # Downloads
+    # ------------------------------------------------------------------
+
+    def download(self, format: str = "json") -> Dict[str, Any]:
+        """Fetch the download response for this run.
+
+        Args:
+            format: ``"json"`` (default) returns ``results`` inline.
+                    ``"urls"`` returns presigned R2 URLs for structure files.
+
+        Returns:
+            Download response dict from the API.
+        """
+        return self._client._get(
+            f"runs/{self.run_id}/download/", params={"format": format}
+        )
+
+    def download_files(
+        self,
+        output_dir: Union[str, Path] = ".",
+        columns: Optional[List[str]] = None,
+        rows: Optional[List[int]] = None,
+        overwrite: bool = False,
+    ) -> List[Path]:
+        """Download structure files (PDB/CIF) to a local directory.
+
+        Fetches presigned R2 download URLs for the specified columns and rows,
+        then saves each file as ``{output_dir}/{row}_{column}.{ext}``.
+
+        Args:
+            output_dir: Directory to save files. Created if it does not exist.
+                Default ``"."`` (current directory).
+            columns: Structure column names to download, e.g. ``["pdb", "designed_pdb"]``.
+                Defaults to auto-detecting structure columns from the results.
+            rows: 1-based row numbers to download. Defaults to all rows up to 500.
+            overwrite: Re-download files that already exist. Default ``False``.
+
+        Returns:
+            List of :class:`pathlib.Path` objects for every file that was written
+            (or already existed when ``overwrite=False``).
+
+        Example::
+
+            paths = run.download_files(
+                output_dir="./structures",
+                columns=["designed_pdb"],
+                rows=list(range(1, 11)),  # first 10 rows
+            )
+        """
+        params: Dict[str, Any] = {"format": "urls"}
+        if columns:
+            params["columns"] = ",".join(columns)
+        if rows:
+            params["rows"] = ",".join(str(r) for r in rows)
+
+        url_data = self._client._get(f"runs/{self.run_id}/download/", params=params)
+        urls: Dict[str, Dict] = url_data.get("urls", {})
+        if not urls:
+            return []
+
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+
+        downloaded: List[Path] = []
+        with httpx.Client(timeout=_DOWNLOAD_TIMEOUT) as http:
+            for row_str, col_map in urls.items():
+                for col, info in col_map.items():
+                    ext = "cif" if "cif" in col else "pdb"
+                    dest = out / f"{row_str}_{col}.{ext}"
+                    if dest.exists() and not overwrite:
+                        downloaded.append(dest)
+                        continue
+                    resp = http.get(info["url"])
+                    resp.raise_for_status()
+                    dest.write_bytes(resp.content)
+                    downloaded.append(dest)
+
+        return downloaded
+
+    # ------------------------------------------------------------------
+    # Cancel
+    # ------------------------------------------------------------------
+
+    def cancel(self) -> None:
+        """Cancel this run if it is still ``scheduled`` or ``running``.
+
+        Raises:
+            :class:`ProtocolRunError`: If the API rejects the cancellation
+                (e.g. run is already in a terminal state).
+        """
+        self._client._delete(f"runs/{self.run_id}/cancel/")
+        self.status = "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# ProtocolClient
+# ---------------------------------------------------------------------------
+
+
+class ProtocolClient:
+    """Client for the BioLM Protocol Submission API.
+
+    Provides a clean interface for discovering, submitting, and retrieving
+    results from BioLM hosted protocols.
+
+    Args:
+        api_key: BioLM API token. Reads ``BIOLMAI_TOKEN`` env var if not provided.
+        base_url: Override the API base domain (default: ``https://biolm.ai``).
+            Useful for pointing at a local dev server::
+
+                client = ProtocolClient(base_url="http://localhost:7777")
+
+    Example::
+
+        import biolmai
+
+        client = biolmai.ProtocolClient()
+
+        # Browse protocols
+        page = client.list(search="antibody")
+        for p in page["results"]:
+            print(p["slug"], p["name"])
+
+        # Inspect required inputs before submitting
+        detail = client.get("antibody-optimization")
+        print(detail["inputs_schema"])
+
+        # Submit and wait (blocking)
+        results = client.run_and_wait(
+            "antibody-optimization",
+            inputs={"sequence": "MKTAYIAKQRQ", "n_rounds": 3},
+        )
+        print(results)
+
+        # Submit async, then download structure files
+        run = client.submit("structure-prediction", inputs={"sequence": "MKLL..."})
+        run.wait()
+        run.download_files("./structures", columns=["pdb"])
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> None:
+        self._api_key = api_key
+        domain = (base_url or BIOLMAI_BASE_DOMAIN).rstrip("/")
+        self._base = f"{domain}/api/protocols"
+
+    # ------------------------------------------------------------------
+    # Internal HTTP helpers
+    # ------------------------------------------------------------------
+
+    def _headers(self) -> Dict[str, str]:
+        return _auth_headers(self._api_key)
+
+    def _url(self, path: str) -> str:
+        url = f"{self._base}/{path.lstrip('/')}"
+        if not url.endswith("/"):
+            url += "/"
+        return url
+
+    def _get(self, path: str, params: Optional[Dict] = None) -> Dict[str, Any]:
+        url = self._url(path)
+        with httpx.Client(timeout=_DEFAULT_TIMEOUT) as http:
+            resp = http.get(url, headers=self._headers(), params=params)
+        if resp.status_code == 404:
+            raise ProtocolNotFoundError(f"Not found: {url}")
+        if not resp.is_success:
+            raise ProtocolRunError(
+                f"GET {url} returned {resp.status_code}: {resp.text[:500]}"
+            )
+        return resp.json()
+
+    def _post(
+        self,
+        path: str,
+        json_body: Optional[Dict] = None,
+        files: Optional[Dict] = None,
+        data: Optional[Dict] = None,
+    ) -> Dict[str, Any]:
+        url = self._url(path)
+        with httpx.Client(timeout=_UPLOAD_TIMEOUT) as http:
+            if files:
+                resp = http.post(url, headers=self._headers(), files=files, data=data)
+            else:
+                resp = http.post(url, headers=self._headers(), json=json_body)
+        if not resp.is_success:
+            raise ProtocolRunError(
+                f"POST {url} returned {resp.status_code}: {resp.text[:500]}"
+            )
+        return resp.json()
+
+    def _delete(self, path: str) -> Dict[str, Any]:
+        url = self._url(path)
+        with httpx.Client(timeout=_DEFAULT_TIMEOUT) as http:
+            resp = http.delete(url, headers=self._headers())
+        if not resp.is_success:
+            raise ProtocolRunError(
+                f"DELETE {url} returned {resp.status_code}: {resp.text[:500]}"
+            )
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Protocol discovery
+    # ------------------------------------------------------------------
+
+    def list(
+        self,
+        search: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> Dict[str, Any]:
+        """List protocols accessible to your account.
+
+        Args:
+            search: Substring match on name or slug.
+            page: Page number (default 1).
+            page_size: Results per page (default 20, max 100).
+
+        Returns:
+            Paginated dict::
+
+                {
+                    "count": 42,
+                    "next": "/api/protocols/?page=2",
+                    "previous": None,
+                    "results": [
+                        {
+                            "slug": "antibody-optimization",
+                            "version": 2,
+                            "name": "Antibody Optimization Pipeline",
+                            "description": "...",
+                            "is_public": True,
+                            "input_fields": ["sequence", "n_rounds"],
+                        },
+                        ...
+                    ]
+                }
+        """
+        params: Dict[str, Any] = {"page": page, "page_size": page_size}
+        if search:
+            params["search"] = search
+        return self._get("", params=params)
+
+    def get(self, slug: str, version: Optional[int] = None) -> Dict[str, Any]:
+        """Get protocol detail and full ``inputs_schema`` for SDK introspection.
+
+        Call this before :meth:`submit` to discover what input fields are required
+        and what types/constraints they have.
+
+        Args:
+            slug: Protocol slug.
+            version: Specific version to fetch. Defaults to the latest published version.
+
+        Returns:
+            Dict::
+
+                {
+                    "slug": "antibody-optimization",
+                    "version": 2,
+                    "name": "Antibody Optimization Pipeline",
+                    "description": "...",
+                    "inputs_schema": {
+                        "sequence": {
+                            "type": "text",
+                            "required": True,
+                            "label": "Input Sequence",
+                            "help_text": "Protein sequence in single-letter code",
+                        },
+                        "n_rounds": {
+                            "type": "integer",
+                            "required": False,
+                            "initial": 3,
+                            "min": 1,
+                            "max": 10,
+                        },
+                    },
+                    "example_inputs": {"sequence": "MKLL...", "n_rounds": 3},
+                }
+
+        Raises:
+            :class:`ProtocolNotFoundError`: If the slug does not exist or is not accessible.
+        """
+        params = {"version": version} if version is not None else None
+        return self._get(f"{slug}/", params=params)
+
+    # ------------------------------------------------------------------
+    # Run submission
+    # ------------------------------------------------------------------
+
+    def submit(
+        self,
+        slug: str,
+        inputs: Dict[str, Any],
+        version: Optional[int] = None,
+        run_name: Optional[str] = None,
+        environment_id: Optional[int] = None,
+        files: Optional[Dict[str, Any]] = None,
+    ) -> ProtocolRun:
+        """Submit a protocol run.
+
+        Args:
+            slug: Protocol slug.
+            inputs: Dict mapping input field names to values, matching the
+                protocol's ``inputs_schema`` (use :meth:`get` to inspect it first).
+            version: Specific protocol version to run. Defaults to latest.
+            run_name: Optional human-readable label for this run.
+            environment_id: Optional environment ID to scope billing and API key usage.
+            files: Optional ``{field_name: file-like-object}`` for file-type inputs.
+                Triggers multipart form submission.
+
+        Returns:
+            :class:`ProtocolRun` — the run is immediately ``scheduled``. Call
+            ``.wait()`` to block until complete, or poll with ``.progress()``.
+
+        Raises:
+            :class:`ProtocolNotFoundError`: If the protocol is not accessible.
+            :class:`ProtocolRunError`: If the server rejects the submission
+                (e.g. invalid inputs or budget exceeded).
+
+        Example::
+
+            run = client.submit(
+                "antibody-optimization",
+                inputs={"sequence": "MKTAYIAKQRQ", "n_rounds": 3},
+                run_name="experiment v7",
+            )
+            print(run.run_id)  # ALY_...
+            run.wait()
+        """
+        if files:
+            form_data: Dict[str, str] = {"inputs": json.dumps(inputs)}
+            if version is not None:
+                form_data["version"] = str(version)
+            if run_name:
+                form_data["run_name"] = run_name
+            if environment_id is not None:
+                form_data["environment_id"] = str(environment_id)
+            multipart = {k: (None, v) for k, v in files.items()}
+            data = self._post(f"{slug}/runs/", files=multipart, data=form_data)
+        else:
+            body: Dict[str, Any] = {"inputs": inputs}
+            if version is not None:
+                body["version"] = version
+            if run_name:
+                body["run_name"] = run_name
+            if environment_id is not None:
+                body["environment_id"] = environment_id
+            data = self._post(f"{slug}/runs/", json_body=body)
+
+        return ProtocolRun(data, client=self)
+
+    # ------------------------------------------------------------------
+    # Run management
+    # ------------------------------------------------------------------
+
+    def runs(
+        self,
+        protocol_slug: Optional[str] = None,
+        status: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> Dict[str, Any]:
+        """List your protocol runs.
+
+        Args:
+            protocol_slug: Filter to runs for a specific protocol.
+            status: Filter by status. One of ``scheduled``, ``running``,
+                ``succeeded``, ``failed``, ``cancelled``.
+            page: Page number (default 1).
+            page_size: Results per page (default 20, max 100).
+
+        Returns:
+            Paginated dict with ``results`` list of run summaries.
+        """
+        params: Dict[str, Any] = {"page": page, "page_size": page_size}
+        if protocol_slug:
+            params["protocol_slug"] = protocol_slug
+        if status:
+            params["status"] = status
+        return self._get("runs/", params=params)
+
+    def get_run(self, run_id: str) -> ProtocolRun:
+        """Reconnect to a previously submitted run by its ID.
+
+        Args:
+            run_id: The ``ALY_...`` run ID from a prior :meth:`submit` call.
+
+        Returns:
+            :class:`ProtocolRun` with current status.
+
+        Example::
+
+            # In a later session:
+            run = client.get_run("ALY_507f1f77bcf86cd799439011")
+            if run.status != "succeeded":
+                run.wait()
+            print(run.results())
+        """
+        data = self._get(f"runs/{run_id}/")
+        return ProtocolRun(
+            {
+                "run_id": data["run_id"],
+                "protocol_slug": data.get("protocol_slug", ""),
+                "protocol_version": data.get("protocol_version", 1),
+                "status": data.get("status", "unknown"),
+            },
+            client=self,
+        )
+
+    # ------------------------------------------------------------------
+    # One-liner convenience
+    # ------------------------------------------------------------------
+
+    def run_and_wait(
+        self,
+        slug: str,
+        inputs: Dict[str, Any],
+        run_name: Optional[str] = None,
+        poll_interval: float = 5.0,
+        timeout: float = 3600.0,
+        show_progress: bool = True,
+    ) -> Dict[str, Any]:
+        """Submit a run, wait for completion, and return results.
+
+        Combines :meth:`submit` + :meth:`ProtocolRun.wait` +
+        :meth:`ProtocolRun.results` into a single blocking call.
+
+        Args:
+            slug: Protocol slug.
+            inputs: Input field values.
+            run_name: Optional run label.
+            poll_interval: Seconds between polls (default 5).
+            timeout: Max seconds to wait (default 3600).
+            show_progress: Print progress updates (default True).
+
+        Returns:
+            The ``results`` payload (``return_json``) from the completed run.
+
+        Raises:
+            :class:`ProtocolRunError`: If the run fails or is cancelled.
+            :class:`TimeoutError`: If ``timeout`` is exceeded.
+
+        Example::
+
+            results = client.run_and_wait(
+                "antibody-optimization",
+                inputs={"sequence": "MKTAYIAKQRQ", "n_rounds": 5},
+            )
+            print(results["designed_sequences"])
+        """
+        run = self.submit(slug, inputs, run_name=run_name)
+        if show_progress:
+            print(f"Submitted: {run.run_id}  [{slug}]")
+        run.wait(poll_interval=poll_interval, timeout=timeout, show_progress=show_progress)
+        return run.results().get("results", {})

--- a/biolmai/protocol_runs.py
+++ b/biolmai/protocol_runs.py
@@ -420,6 +420,117 @@ class ProtocolRun:
             with zf.open(csv_names[0]) as f:
                 return pd.read_csv(io.TextIOWrapper(f, encoding="utf-8"))
 
+    def to_duckdb(
+        self,
+        con=None,
+        table: Optional[str] = None,
+        if_exists: str = "replace",
+        add_run_metadata: bool = True,
+        output_dir: Union[str, Path] = ".",
+        overwrite: bool = False,
+    ):
+        """Load protocol run results directly into a DuckDB table.
+
+        Downloads the CSV results zip (cached locally after the first call)
+        and inserts them into a DuckDB table.  Pass an existing connection to
+        integrate with a pipeline datastore; omit *con* to get a new
+        in-memory DuckDB.
+
+        Args:
+            con: A ``duckdb.DuckDBPyConnection``, a path string/``Path`` to a
+                ``.duckdb`` file, or ``None`` (creates an in-memory connection
+                and returns it).
+            table: Table name.  Defaults to the protocol slug with ``-`` and
+                ``.`` replaced by ``_``
+                (e.g. ``esm2stabp_predict_from_sequences``).
+            if_exists: What to do when the table already exists.
+                ``"replace"`` (default) drops and recreates it; ``"append"``
+                inserts rows without truncating; ``"fail"`` raises
+                ``ValueError``.
+            add_run_metadata: If ``True`` (default), prepend ``_run_id`` and
+                ``_protocol_slug`` columns so results from multiple runs stay
+                traceable after appending.
+            output_dir: Where to cache the downloaded zip file.
+            overwrite: Re-download the zip even if it already exists locally.
+
+        Returns:
+            The ``duckdb.DuckDBPyConnection`` used (the caller's connection,
+            or the new in-memory connection when *con* was ``None``).
+
+        Raises:
+            :class:`ProtocolRunError`: If the run has not yet succeeded.
+            ``ValueError``: If *if_exists* is invalid, or if *if_exists* is
+                ``"fail"`` and the table already exists.
+            ``ImportError``: If ``duckdb`` or ``pandas`` are not installed.
+
+        Example::
+
+            import duckdb
+
+            con = duckdb.connect("results.duckdb")
+            run.to_duckdb(con, table="stability_results")
+            con.execute("SELECT * FROM stability_results LIMIT 5").df()
+
+            # Append results from multiple runs into the same table:
+            for run in completed_runs:
+                run.to_duckdb(con, table="stability_results", if_exists="append")
+
+            # In-memory quick exploration — no file needed:
+            con = run.to_duckdb()
+            con.sql("SELECT * FROM esm2stabp_predict_from_sequences").show()
+        """
+        try:
+            import duckdb
+        except ImportError:
+            raise ImportError(
+                "duckdb is required for run.to_duckdb(). "
+                "Install it: pip install biolmai[pipeline]"
+            )
+
+        _VALID = {"replace", "append", "fail"}
+        if if_exists not in _VALID:
+            raise ValueError(
+                f"if_exists must be one of {sorted(_VALID)!r}, got {if_exists!r}."
+            )
+
+        # Resolve connection — own_con means we opened it and should return it
+        if con is None or isinstance(con, (str, Path)):
+            con = duckdb.connect(str(con) if con is not None else ":memory:")
+
+        # Default table name: sanitize slug
+        if table is None:
+            slug = self.protocol_slug or self.run_id or "protocol_results"
+            table = slug.replace("-", "_").replace(".", "_")
+
+        # Check for existing table
+        table_exists = con.execute(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = ?",
+            [table],
+        ).fetchone()[0]
+
+        if table_exists and if_exists == "fail":
+            raise ValueError(
+                f"Table {table!r} already exists and if_exists='fail'."
+            )
+
+        # Download CSV and load into pandas (reuses to_dataframe logic)
+        df = self.to_dataframe(output_dir=output_dir, overwrite=overwrite)
+
+        if add_run_metadata:
+            df.insert(0, "_protocol_slug", self.protocol_slug)
+            df.insert(0, "_run_id", self.run_id)
+
+        if table_exists and if_exists == "replace":
+            con.execute(f'DROP TABLE "{table}"')
+            table_exists = False
+
+        if not table_exists:
+            con.execute(f'CREATE TABLE "{table}" AS SELECT * FROM df')
+        else:
+            con.execute(f'INSERT INTO "{table}" SELECT * FROM df')
+
+        return con
+
     # ------------------------------------------------------------------
     # Cancel
     # ------------------------------------------------------------------

--- a/biolmai/protocol_runs.py
+++ b/biolmai/protocol_runs.py
@@ -256,7 +256,7 @@ class ProtocolRun:
             Download response dict from the API.
         """
         return self._client._get(
-            f"runs/{self.run_id}/download/", params={"format": format}
+            f"runs/{self.run_id}/download/", params={"output": format}
         )
 
     def download_files(
@@ -291,7 +291,7 @@ class ProtocolRun:
                 rows=list(range(1, 11)),  # first 10 rows
             )
         """
-        params: Dict[str, Any] = {"format": "urls"}
+        params: Dict[str, Any] = {"output": "urls"}
         if columns:
             params["columns"] = ",".join(columns)
         if rows:

--- a/biolmai/protocol_runs.py
+++ b/biolmai/protocol_runs.py
@@ -186,8 +186,10 @@ class ProtocolRun:
                 time.sleep(poll_interval)
                 continue
 
-            if show_progress and self.status != last_status:
-                print(f"  [{self.run_id}] {self.status}")
+            if show_progress:
+                pct = snap.get("progress_pct")
+                pct_str = f" {pct}%" if pct is not None else ""
+                print(f"  [{self.run_id}] {self.status}{pct_str}")
                 last_status = self.status
 
             if self.status in ("succeeded", "failed", "cancelled"):
@@ -295,20 +297,76 @@ class ProtocolRun:
     def download_files(
         self,
         output_dir: Union[str, Path] = ".",
-        file_type: str = "csv",
+        columns: Optional[List[str]] = None,
         overwrite: bool = False,
-    ) -> Path:
-        """Alias for :meth:`download` — downloads the compressed results file.
+    ) -> List[Path]:
+        """Download individual output files via presigned URLs.
+
+        Fetches the per-row / per-column URL manifest from the server and
+        downloads each file to ``output_dir``.  Files are named
+        ``{row_id}_{column_name}{ext}`` where the extension is inferred from
+        the presigned URL.
 
         Args:
-            output_dir: Directory to save the file. Default ``"."``.
-            file_type: ``"csv"`` (default) or ``"jsonl"``.
-            overwrite: Re-download if already exists. Default ``False``.
+            output_dir: Directory to save files. Created if it does not exist.
+            columns: Optional list of column names to download.  If ``None``
+                (default) all columns are downloaded.
+            overwrite: Re-download files that already exist. Default ``False``.
 
         Returns:
-            :class:`pathlib.Path` to the downloaded zip file.
+            List of :class:`pathlib.Path` objects for every file (including
+            ones that were already present when ``overwrite=False``).
+
+        Raises:
+            :class:`ProtocolRunError`: If fetching the URL manifest fails.
+
+        Example::
+
+            paths = run.download_files("./structures", columns=["pdb"])
         """
-        return self.download(output_dir=output_dir, file_type=file_type, overwrite=overwrite)
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+
+        url = self._client._url(f"runs/{self.run_id}/download/")
+        paths: List[Path] = []
+
+        with httpx.Client(timeout=_DOWNLOAD_TIMEOUT) as http:
+            # 1. Fetch the URL manifest for this run
+            manifest_resp = http.get(url, headers=self._client._headers())
+            if not manifest_resp.is_success:
+                raise ProtocolRunError(
+                    f"Failed to fetch download URLs for run {self.run_id}: "
+                    f"{manifest_resp.status_code}"
+                )
+            urls_by_row: dict = manifest_resp.json().get("urls", {})
+
+            if not urls_by_row:
+                return []
+
+            # 2. Download each (row, column) file
+            for row_id, cols in urls_by_row.items():
+                for col_name, url_info in cols.items():
+                    if columns is not None and col_name not in columns:
+                        continue
+                    file_url = url_info["url"] if isinstance(url_info, dict) else url_info
+                    # Infer file extension from the presigned URL path (before query string)
+                    ext = Path(file_url.split("?")[0]).suffix
+                    dest = out / f"{row_id}_{col_name}{ext}"
+
+                    if dest.exists() and not overwrite:
+                        paths.append(dest)
+                        continue
+
+                    file_resp = http.get(file_url)
+                    if not file_resp.is_success:
+                        raise ProtocolRunError(
+                            f"Failed to download {col_name} for row {row_id}: "
+                            f"{file_resp.status_code}"
+                        )
+                    dest.write_bytes(file_resp.content)
+                    paths.append(dest)
+
+        return paths
 
     # ------------------------------------------------------------------
     # Cancel
@@ -686,4 +744,4 @@ class ProtocolClient:
         if show_progress:
             print(f"Submitted: {run.run_id}  [{slug}]")
         run.wait(poll_interval=poll_interval, timeout=timeout, show_progress=show_progress)
-        return run.results()
+        return run.results().get("results", {})

--- a/biolmai/protocol_runs.py
+++ b/biolmai/protocol_runs.py
@@ -20,15 +20,15 @@ Usage::
         run_name="my first run",
     )
 
-    # Option A — block until complete
+    # Option A — block until complete, then download results
     run.wait()
-    print(run.results())
+    path = run.download(output_dir="./results")  # saves ALY_xxx_results.csv.zip
 
-    # Option B — one-liner
-    results = client.run_and_wait("antibody-optimization", inputs={"sequence": "MKTAYIAKQRQ"})
+    # Option B — one-liner (returns run detail dict)
+    detail = client.run_and_wait("antibody-optimization", inputs={"sequence": "MKTAYIAKQRQ"})
 
-    # Download structure files after completion
-    paths = run.download_files(output_dir="./structures", columns=["designed_pdb"])
+    # Download the compressed results file
+    path = run.download(output_dir="./results", file_type="jsonl")
 """
 
 import json
@@ -118,25 +118,20 @@ class ProtocolRun:
         return self
 
     def progress(self) -> Dict[str, Any]:
-        """Return a live progress snapshot for this run.
+        """Return the current status and WebSocket channel for this run.
 
-        Reads from the same event log as the browser console's live view.
+        For live progress events (log lines, task statuses, per-step updates),
+        subscribe to the WebSocket channel returned in ``channel_id`` — the
+        same channel the browser console uses.
 
         Returns:
             Dict with keys:
 
             - ``status`` — current run status
-            - ``progress_pct`` — 0–100 integer, or ``None`` if not yet available
-            - ``tasks`` — list of per-task dicts (``name``, ``status``,
-              ``completed_subtasks``, ``total_subtasks``, ``failed_subtasks``)
-            - ``log_lines`` — last 50 log lines (newest last)
-            - ``result_row_count`` — rows emitted so far, or ``None``
+            - ``channel_id`` — WebSocket pub/sub channel for live events
+              (e.g. ``telemetry_ALY_...``). Connect to ``/ws/`` and subscribe.
         """
         return self._client._get(f"runs/{self.run_id}/progress/")
-
-    def log_lines(self) -> List[str]:
-        """Convenience wrapper — returns the latest log lines from :meth:`progress`."""
-        return self.progress().get("log_lines", [])
 
     # ------------------------------------------------------------------
     # Blocking wait
@@ -170,7 +165,7 @@ class ProtocolRun:
             print(run.results())
         """
         deadline = time.monotonic() + timeout
-        last_pct: Optional[int] = None
+        last_status: Optional[str] = None
 
         while True:
             if time.monotonic() > deadline:
@@ -181,8 +176,9 @@ class ProtocolRun:
 
             try:
                 snap = self.progress()
+                self.status = snap.get("status", self.status)
             except Exception:
-                # Network blip — refresh plain status and retry
+                # Network blip — fall back to detail endpoint for status
                 try:
                     self.refresh()
                 except Exception:
@@ -190,18 +186,9 @@ class ProtocolRun:
                 time.sleep(poll_interval)
                 continue
 
-            self.status = snap.get("status", self.status)
-            pct: Optional[int] = snap.get("progress_pct")
-            tasks: List[Dict] = snap.get("tasks", [])
-
-            if show_progress and pct != last_pct:
-                running = [t["name"] for t in tasks if t.get("status") == "running"]
-                if pct is not None:
-                    suffix = f" — {running[0]}" if running else ""
-                    print(f"  [{self.run_id}] {pct:>3}%{suffix}")
-                elif running:
-                    print(f"  [{self.run_id}] running: {', '.join(running)}")
-                last_pct = pct
+            if show_progress and self.status != last_status:
+                print(f"  [{self.run_id}] {self.status}")
+                last_status = self.status
 
             if self.status in ("succeeded", "failed", "cancelled"):
                 break
@@ -228,16 +215,19 @@ class ProtocolRun:
     # ------------------------------------------------------------------
 
     def results(self) -> Dict[str, Any]:
-        """Fetch the full run detail including the results payload.
+        """Fetch the run detail (status, timestamps, failure info).
+
+        The actual result data (CSV/JSONL rows) is in the download stream —
+        use :meth:`download` to save the compressed results file locally.
 
         Returns:
             Dict with keys:
 
             - ``run_id``, ``protocol_slug``, ``protocol_version``
             - ``status``
-            - ``results`` — the ``return_json`` from the server (may be large)
+            - ``results`` — mapped output fields (may be empty if no response_mapping)
             - ``failure_error`` — error message if failed, else ``None``
-            - ``workflow_started_at``, ``workflow_ended_at``, ``expires_at``
+            - ``workflow_started_at``, ``workflow_ended_at``
         """
         return self._client._get(f"runs/{self.run_id}/")
 
@@ -245,81 +235,80 @@ class ProtocolRun:
     # Downloads
     # ------------------------------------------------------------------
 
-    def download(self, format: str = "json") -> Dict[str, Any]:
-        """Fetch the download response for this run.
+    def download(
+        self,
+        output_dir: Union[str, Path] = ".",
+        file_type: str = "csv",
+        overwrite: bool = False,
+    ) -> Path:
+        """Download the compressed results file for this run.
+
+        Streams the results zip (CSV or JSONL) directly from the server and
+        saves it to ``output_dir``.
 
         Args:
-            format: ``"json"`` (default) returns ``results`` inline.
-                    ``"urls"`` returns presigned R2 URLs for structure files.
+            output_dir: Directory to save the file. Created if it does not exist.
+                Default ``"."`` (current directory).
+            file_type: ``"csv"`` (default) or ``"jsonl"``. Selects which
+                compressed results file to download.
+            overwrite: Re-download if the file already exists. Default ``False``.
 
         Returns:
-            Download response dict from the API.
+            :class:`pathlib.Path` to the downloaded zip file.
+
+        Raises:
+            :class:`ProtocolRunError`: If the run has not yet succeeded or the
+                download fails.
+
+        Example::
+
+            path = run.download(output_dir="./results")
+            # path → PosixPath('./results/ALY_xxx_results.csv.zip')
         """
-        return self._client._get(
-            f"runs/{self.run_id}/download/", params={"output": format}
-        )
+        out = Path(output_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        dest = out / f"{self.run_id}_results.{file_type}.zip"
+
+        if dest.exists() and not overwrite:
+            return dest
+
+        url = self._client._url(f"runs/{self.run_id}/download/")
+        params = {"file_type": file_type}
+        with httpx.Client(timeout=_DOWNLOAD_TIMEOUT) as http:
+            with http.stream(
+                "GET", url, headers=self._client._headers(), params=params
+            ) as resp:
+                if resp.status_code == 400:
+                    raise ProtocolRunError(
+                        f"Run {self.run_id} is not complete — cannot download yet."
+                    )
+                if not resp.is_success:
+                    raise ProtocolRunError(
+                        f"Download failed: {resp.status_code} {resp.text[:200]}"
+                    )
+                with dest.open("wb") as f:
+                    for chunk in resp.iter_bytes(chunk_size=65536):
+                        f.write(chunk)
+
+        return dest
 
     def download_files(
         self,
         output_dir: Union[str, Path] = ".",
-        columns: Optional[List[str]] = None,
-        rows: Optional[List[int]] = None,
+        file_type: str = "csv",
         overwrite: bool = False,
-    ) -> List[Path]:
-        """Download structure files (PDB/CIF) to a local directory.
-
-        Fetches presigned R2 download URLs for the specified columns and rows,
-        then saves each file as ``{output_dir}/{row}_{column}.{ext}``.
+    ) -> Path:
+        """Alias for :meth:`download` — downloads the compressed results file.
 
         Args:
-            output_dir: Directory to save files. Created if it does not exist.
-                Default ``"."`` (current directory).
-            columns: Structure column names to download, e.g. ``["pdb", "designed_pdb"]``.
-                Defaults to auto-detecting structure columns from the results.
-            rows: 1-based row numbers to download. Defaults to all rows up to 500.
-            overwrite: Re-download files that already exist. Default ``False``.
+            output_dir: Directory to save the file. Default ``"."``.
+            file_type: ``"csv"`` (default) or ``"jsonl"``.
+            overwrite: Re-download if already exists. Default ``False``.
 
         Returns:
-            List of :class:`pathlib.Path` objects for every file that was written
-            (or already existed when ``overwrite=False``).
-
-        Example::
-
-            paths = run.download_files(
-                output_dir="./structures",
-                columns=["designed_pdb"],
-                rows=list(range(1, 11)),  # first 10 rows
-            )
+            :class:`pathlib.Path` to the downloaded zip file.
         """
-        params: Dict[str, Any] = {"output": "urls"}
-        if columns:
-            params["columns"] = ",".join(columns)
-        if rows:
-            params["rows"] = ",".join(str(r) for r in rows)
-
-        url_data = self._client._get(f"runs/{self.run_id}/download/", params=params)
-        urls: Dict[str, Dict] = url_data.get("urls", {})
-        if not urls:
-            return []
-
-        out = Path(output_dir)
-        out.mkdir(parents=True, exist_ok=True)
-
-        downloaded: List[Path] = []
-        with httpx.Client(timeout=_DOWNLOAD_TIMEOUT) as http:
-            for row_str, col_map in urls.items():
-                for col, info in col_map.items():
-                    ext = "cif" if "cif" in col else "pdb"
-                    dest = out / f"{row_str}_{col}.{ext}"
-                    if dest.exists() and not overwrite:
-                        downloaded.append(dest)
-                        continue
-                    resp = http.get(info["url"])
-                    resp.raise_for_status()
-                    dest.write_bytes(resp.content)
-                    downloaded.append(dest)
-
-        return downloaded
+        return self.download(output_dir=output_dir, file_type=file_type, overwrite=overwrite)
 
     # ------------------------------------------------------------------
     # Cancel
@@ -680,7 +669,8 @@ class ProtocolClient:
             show_progress: Print progress updates (default True).
 
         Returns:
-            The ``results`` payload (``return_json``) from the completed run.
+            Run detail dict (``run_id``, ``status``, timestamps, etc.).
+            For the actual result rows, call ``run.download()`` after this returns.
 
         Raises:
             :class:`ProtocolRunError`: If the run fails or is cancelled.
@@ -688,14 +678,12 @@ class ProtocolClient:
 
         Example::
 
-            results = client.run_and_wait(
-                "antibody-optimization",
-                inputs={"sequence": "MKTAYIAKQRQ", "n_rounds": 5},
-            )
-            print(results["designed_sequences"])
+            run = client.submit("antibody-optimization", inputs={"sequence": "MKTAYIAKQRQ"})
+            run.wait()
+            path = run.download(output_dir="./results")  # saves the CSV zip
         """
         run = self.submit(slug, inputs, run_name=run_name)
         if show_progress:
             print(f"Submitted: {run.run_id}  [{slug}]")
         run.wait(poll_interval=poll_interval, timeout=timeout, show_progress=show_progress)
-        return run.results().get("results", {})
+        return run.results()

--- a/biolmai/protocol_runs.py
+++ b/biolmai/protocol_runs.py
@@ -31,9 +31,10 @@ Usage::
     path = run.download(output_dir="./results", file_type="jsonl")
 """
 
+import io
 import json
 import os
-import time
+import zipfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
@@ -164,53 +165,90 @@ class ProtocolRun:
             run.wait(poll_interval=10, timeout=7200)
             print(run.results())
         """
-        deadline = time.monotonic() + timeout
-        last_status: Optional[str] = None
+        # Fetch channel_id for this run (single HTTP call — not a poll loop)
+        snap = self.progress()
+        self.status = snap.get("status", self.status)
+        channel_id = snap.get("channel_id", f"telemetry_{self.run_id}")
 
-        while True:
-            if time.monotonic() > deadline:
-                raise TimeoutError(
-                    f"Protocol run {self.run_id} did not complete within {timeout:.0f}s. "
-                    "Increase timeout= or poll manually with run.progress()."
-                )
-
-            try:
-                snap = self.progress()
-                self.status = snap.get("status", self.status)
-            except Exception:
-                # Network blip — fall back to detail endpoint for status
-                try:
-                    self.refresh()
-                except Exception:
-                    pass
-                time.sleep(poll_interval)
-                continue
-
+        if self.status in ("succeeded", "failed", "cancelled"):
             if show_progress:
                 pct = snap.get("progress_pct")
                 pct_str = f" {pct}%" if pct is not None else ""
                 print(f"  [{self.run_id}] {self.status}{pct_str}")
-                last_status = self.status
+            self._check_terminal()
+            return self
 
-            if self.status in ("succeeded", "failed", "cancelled"):
-                break
+        domain = self._client._base.replace("https://", "").replace("http://", "").split("/")[0]
+        ws_url = f"wss://{domain}/ws/telemetry/{channel_id}/"
 
-            time.sleep(poll_interval)
+        self._listen_ws(ws_url, show_progress=show_progress, timeout=timeout)
 
+        self._check_terminal()
+        if show_progress:
+            print(f"  [{self.run_id}] complete ✓")
+        return self
+
+    def _listen_ws(self, ws_url: str, show_progress: bool = True, timeout: float = 3600.0) -> None:
+        """Connect to the telemetry WebSocket and block until this run reaches a terminal state.
+
+        Extracted as a separate method so tests can patch it without async machinery.
+        """
+        try:
+            import asyncio
+            import websockets
+        except ImportError:
+            raise ImportError(
+                "websockets is required for run.wait(). "
+                "Install it: pip install websockets"
+            )
+
+        async def _listen():
+            extra_headers = list(self._client._headers().items())
+            async with websockets.connect(
+                ws_url,
+                additional_headers=extra_headers,
+                open_timeout=_DEFAULT_TIMEOUT,
+                close_timeout=10,
+                ping_interval=8,
+                ping_timeout=5,
+            ) as ws:
+                async for raw in ws:
+                    data = json.loads(raw) if isinstance(raw, str) else raw
+                    env = data.get("data", data) if isinstance(data, dict) else {}
+                    payload = env.get("payload", env)
+                    status = payload.get("status") or env.get("status")
+                    pct = payload.get("progress_pct") or env.get("progress_pct")
+                    if status:
+                        self.status = status
+                    if show_progress:
+                        pct_str = f" {pct}%" if pct is not None else ""
+                        print(f"  [{self.run_id}] {self.status}{pct_str}")
+                    if self.status in ("succeeded", "failed", "cancelled"):
+                        return
+
+        try:
+            asyncio.run(_listen())
+        except Exception as exc:
+            try:
+                self.refresh()
+            except Exception:
+                pass
+            if self.status not in ("succeeded", "failed", "cancelled"):
+                raise ProtocolRunError(
+                    f"WebSocket connection lost for run {self.run_id}: {exc}. "
+                    f"Last known status: {self.status}"
+                ) from exc
+
+    def _check_terminal(self) -> None:
+        """Raise if status is failed or cancelled."""
         if self.status == "failed":
             try:
                 detail = self._client._get(f"runs/{self.run_id}/").get("failure_error") or "unknown error"
             except Exception:
                 detail = "unknown error"
             raise ProtocolRunError(f"Protocol run {self.run_id} failed: {detail}")
-
         if self.status == "cancelled":
             raise ProtocolRunError(f"Protocol run {self.run_id} was cancelled.")
-
-        if show_progress:
-            print(f"  [{self.run_id}] complete ✓")
-
-        return self
 
     # ------------------------------------------------------------------
     # Results
@@ -297,76 +335,63 @@ class ProtocolRun:
     def download_files(
         self,
         output_dir: Union[str, Path] = ".",
-        columns: Optional[List[str]] = None,
+        file_type: str = "csv",
         overwrite: bool = False,
-    ) -> List[Path]:
-        """Download individual output files via presigned URLs.
-
-        Fetches the per-row / per-column URL manifest from the server and
-        downloads each file to ``output_dir``.  Files are named
-        ``{row_id}_{column_name}{ext}`` where the extension is inferred from
-        the presigned URL.
+    ) -> Path:
+        """Alias for :meth:`download` — downloads the compressed results file.
 
         Args:
-            output_dir: Directory to save files. Created if it does not exist.
-            columns: Optional list of column names to download.  If ``None``
-                (default) all columns are downloaded.
-            overwrite: Re-download files that already exist. Default ``False``.
+            output_dir: Directory to save the file. Default ``"."``.
+            file_type: ``"csv"`` (default) or ``"jsonl"``.
+            overwrite: Re-download if already exists. Default ``False``.
 
         Returns:
-            List of :class:`pathlib.Path` objects for every file (including
-            ones that were already present when ``overwrite=False``).
+            :class:`pathlib.Path` to the downloaded zip file.
+        """
+        return self.download(output_dir=output_dir, file_type=file_type, overwrite=overwrite)
 
-        Raises:
-            :class:`ProtocolRunError`: If fetching the URL manifest fails.
+    def to_dataframe(
+        self,
+        output_dir: Union[str, Path] = ".",
+        overwrite: bool = False,
+    ):
+        """Download the results zip and parse it into a :class:`pandas.DataFrame`.
+
+        Downloads the CSV zip (if not already cached) then reads the first CSV
+        file inside it.  Requires ``pandas`` — install via
+        ``pip install biolmai[pipeline]``.
+
+        Args:
+            output_dir: Where to cache the downloaded zip. Default ``"."``.
+            overwrite: Re-download even if the zip already exists.
+
+        Returns:
+            :class:`pandas.DataFrame` with one row per result record.
 
         Example::
 
-            paths = run.download_files("./structures", columns=["pdb"])
+            df = run.to_dataframe(output_dir="./results")
+            print(df.head())
         """
-        out = Path(output_dir)
-        out.mkdir(parents=True, exist_ok=True)
+        try:
+            import pandas as pd
+        except ImportError:
+            raise ImportError(
+                "pandas is required for run.to_dataframe(). "
+                "Install it: pip install biolmai[pipeline]"
+            )
 
-        url = self._client._url(f"runs/{self.run_id}/download/")
-        paths: List[Path] = []
+        zip_path = self.download(output_dir=output_dir, file_type="csv", overwrite=overwrite)
 
-        with httpx.Client(timeout=_DOWNLOAD_TIMEOUT) as http:
-            # 1. Fetch the URL manifest for this run
-            manifest_resp = http.get(url, headers=self._client._headers())
-            if not manifest_resp.is_success:
+        with zipfile.ZipFile(zip_path) as zf:
+            csv_names = [n for n in zf.namelist() if n.endswith(".csv")]
+            if not csv_names:
                 raise ProtocolRunError(
-                    f"Failed to fetch download URLs for run {self.run_id}: "
-                    f"{manifest_resp.status_code}"
+                    f"No CSV file found inside {zip_path.name}. "
+                    "Try run.download(file_type='jsonl') for JSONL output."
                 )
-            urls_by_row: dict = manifest_resp.json().get("urls", {})
-
-            if not urls_by_row:
-                return []
-
-            # 2. Download each (row, column) file
-            for row_id, cols in urls_by_row.items():
-                for col_name, url_info in cols.items():
-                    if columns is not None and col_name not in columns:
-                        continue
-                    file_url = url_info["url"] if isinstance(url_info, dict) else url_info
-                    # Infer file extension from the presigned URL path (before query string)
-                    ext = Path(file_url.split("?")[0]).suffix
-                    dest = out / f"{row_id}_{col_name}{ext}"
-
-                    if dest.exists() and not overwrite:
-                        paths.append(dest)
-                        continue
-
-                    file_resp = http.get(file_url)
-                    if not file_resp.is_success:
-                        raise ProtocolRunError(
-                            f"Failed to download {col_name} for row {row_id}: "
-                            f"{file_resp.status_code}"
-                        )
-                    dest.write_bytes(file_resp.content)
-                    paths.append(dest)
-
-        return paths
+            with zf.open(csv_names[0]) as f:
+                return pd.read_csv(io.TextIOWrapper(f, encoding="utf-8"))
 
     # ------------------------------------------------------------------
     # Cancel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ dependencies = [
     "rich>=13.0.0",
     "pyyaml>=5.0",
     "jsonschema>=4.0,<5",
+    "websockets>=11.0",
 ]
 scripts = { biolmai = "biolmai.cli_entry:cli" }
 

--- a/tests/test_protocol_client.py
+++ b/tests/test_protocol_client.py
@@ -1,0 +1,666 @@
+"""Tests for ProtocolClient, ProtocolRun, and the top-level run_protocol() function.
+
+HTTP calls are mocked entirely via unittest.mock.patch on httpx.Client so no real
+network requests are made. Each _get / _post / _delete helper opens httpx.Client as
+a context manager, so the mock hierarchy is:
+
+    mock_client_cls.return_value.__enter__.return_value  →  mock_http (the "session")
+    mock_http.get.return_value   / .post.return_value / .delete.return_value
+        .status_code, .is_success, .text, .json(), .content
+
+Tests are grouped into three classes:
+    TestProtocolClient  — auth + list / get / submit / get_run / run_and_wait
+    TestProtocolRun     — wait / progress / results / download_files / cancel / refresh
+    TestTopLevel        — biolmai.run_protocol()
+"""
+
+import io
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import httpx
+import pytest
+
+from biolmai.protocol_runs import (
+    ProtocolClient,
+    ProtocolNotFoundError,
+    ProtocolRun,
+    ProtocolRunError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_RUN_ID = "ALY_abc123"
+_SLUG = "my-proto"
+_TOKEN = "test-token-xyz"
+
+# Minimal ProtocolRun data dict
+_RUN_DATA = {
+    "run_id": _RUN_ID,
+    "protocol_slug": _SLUG,
+    "protocol_version": 1,
+    "status": "scheduled",
+}
+
+
+def _make_client(token: str = _TOKEN, base_url: str = "https://biolm.ai") -> ProtocolClient:
+    """Return a ProtocolClient with a known token, no env dependency."""
+    return ProtocolClient(api_key=token, base_url=base_url)
+
+
+def _mock_response(
+    status_code: int = 200,
+    json_data: object = None,
+    text: str = "",
+    content: bytes = b"",
+) -> MagicMock:
+    """Build a fake httpx.Response-like mock."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.text = text or (str(json_data) if json_data is not None else "")
+    resp.json.return_value = json_data if json_data is not None else {}
+    resp.content = content
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _patch_httpx_client(method: str, response: MagicMock):
+    """Context-manager factory: patches httpx.Client so that ``method`` (get/post/delete)
+    returns *response*.  Returns the patch object (use as context manager)."""
+    mock_cls = MagicMock()
+    mock_http = MagicMock()
+    mock_cls.return_value.__enter__.return_value = mock_http
+    mock_cls.return_value.__exit__.return_value = False
+    getattr(mock_http, method).return_value = response
+    return mock_cls, mock_http
+
+
+# ---------------------------------------------------------------------------
+# TestProtocolClient
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolClient:
+    """Tests for ProtocolClient auth, list, get, submit, get_run, run_and_wait."""
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+
+    def test_no_token_raises(self, monkeypatch):
+        """ProtocolClient with no token source raises ValueError with helpful message."""
+        monkeypatch.delenv("BIOLMAI_TOKEN", raising=False)
+        monkeypatch.delenv("BIOLM_TOKEN", raising=False)
+        client = ProtocolClient()  # no api_key= kwarg
+
+        mock_cls, mock_http = _patch_httpx_client("get", _mock_response(200, {}))
+        with patch("httpx.Client", mock_cls):
+            with pytest.raises(ValueError, match="BIOLMAI_TOKEN"):
+                client._get("")
+
+    def test_token_from_env(self, monkeypatch):
+        """BIOLMAI_TOKEN env var is used in the Authorization header."""
+        monkeypatch.setenv("BIOLMAI_TOKEN", "env-token-123")
+        client = ProtocolClient()
+
+        resp = _mock_response(200, {"count": 0, "results": []})
+        mock_cls, mock_http = _patch_httpx_client("get", resp)
+        with patch("httpx.Client", mock_cls):
+            client._get("")
+
+        call_kwargs = mock_http.get.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
+        assert headers.get("Authorization") == "Token env-token-123"
+
+    def test_token_from_arg(self, monkeypatch):
+        """api_key= kwarg takes precedence over BIOLMAI_TOKEN env var."""
+        monkeypatch.setenv("BIOLMAI_TOKEN", "env-token-999")
+        client = ProtocolClient(api_key="kwarg-token-456")
+
+        resp = _mock_response(200, {"count": 0, "results": []})
+        mock_cls, mock_http = _patch_httpx_client("get", resp)
+        with patch("httpx.Client", mock_cls):
+            client._get("")
+
+        call_kwargs = mock_http.get.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers", {})
+        assert headers.get("Authorization") == "Token kwarg-token-456"
+
+    # ------------------------------------------------------------------
+    # list()
+    # ------------------------------------------------------------------
+
+    def test_list_success(self):
+        """list() returns paginated dict from the GET response."""
+        payload = {"count": 2, "next": None, "previous": None, "results": [{"slug": "a"}, {"slug": "b"}]}
+        client = _make_client()
+        resp = _mock_response(200, payload)
+        mock_cls, _ = _patch_httpx_client("get", resp)
+
+        with patch("httpx.Client", mock_cls):
+            result = client.list()
+
+        assert result["count"] == 2
+        assert len(result["results"]) == 2
+
+    def test_list_search_param(self):
+        """list(search='antibody') includes ?search=antibody in the request params."""
+        client = _make_client()
+        resp = _mock_response(200, {"count": 0, "results": []})
+        mock_cls, mock_http = _patch_httpx_client("get", resp)
+
+        with patch("httpx.Client", mock_cls):
+            client.list(search="antibody")
+
+        call_kwargs = mock_http.get.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params", {})
+        assert params.get("search") == "antibody"
+
+    def test_list_http_error(self):
+        """list() raises ProtocolRunError when the server returns 500."""
+        client = _make_client()
+        resp = _mock_response(500, text="internal server error")
+        mock_cls, _ = _patch_httpx_client("get", resp)
+
+        with patch("httpx.Client", mock_cls):
+            with pytest.raises(ProtocolRunError, match="500"):
+                client.list()
+
+    # ------------------------------------------------------------------
+    # get()
+    # ------------------------------------------------------------------
+
+    def test_get_success(self):
+        """get() returns protocol detail with inputs_schema present."""
+        payload = {
+            "slug": _SLUG,
+            "version": 1,
+            "inputs_schema": {"sequence": {"type": "text", "required": True}},
+        }
+        client = _make_client()
+        resp = _mock_response(200, payload)
+        mock_cls, _ = _patch_httpx_client("get", resp)
+
+        with patch("httpx.Client", mock_cls):
+            result = client.get(_SLUG)
+
+        assert "inputs_schema" in result
+        assert result["slug"] == _SLUG
+
+    def test_get_with_version(self):
+        """get(slug, version=2) passes ?version=2 in the request params."""
+        client = _make_client()
+        resp = _mock_response(200, {"slug": _SLUG, "version": 2, "inputs_schema": {}})
+        mock_cls, mock_http = _patch_httpx_client("get", resp)
+
+        with patch("httpx.Client", mock_cls):
+            client.get(_SLUG, version=2)
+
+        call_kwargs = mock_http.get.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params", {})
+        assert params.get("version") == 2
+
+    def test_get_404(self):
+        """get() raises ProtocolNotFoundError on 404."""
+        client = _make_client()
+        resp = _mock_response(404, text="not found")
+        mock_cls, _ = _patch_httpx_client("get", resp)
+
+        with patch("httpx.Client", mock_cls):
+            with pytest.raises(ProtocolNotFoundError):
+                client.get("nonexistent-slug")
+
+    # ------------------------------------------------------------------
+    # submit()
+    # ------------------------------------------------------------------
+
+    def test_submit_returns_protocol_run(self):
+        """submit() returns a ProtocolRun with run_id, protocol_slug, and status."""
+        payload = {"run_id": _RUN_ID, "protocol_slug": _SLUG, "status": "scheduled"}
+        client = _make_client()
+        resp = _mock_response(200, payload)
+        mock_cls, _ = _patch_httpx_client("post", resp)
+
+        with patch("httpx.Client", mock_cls):
+            run = client.submit(_SLUG, inputs={"sequence": "MKTAY"})
+
+        assert isinstance(run, ProtocolRun)
+        assert run.run_id == _RUN_ID
+        assert run.protocol_slug == _SLUG
+        assert run.status == "scheduled"
+
+    def test_submit_json_body(self):
+        """submit() sends JSON body containing 'inputs' (and optional run_name)."""
+        import json as _json
+
+        payload = {"run_id": _RUN_ID, "protocol_slug": _SLUG, "status": "scheduled"}
+        client = _make_client()
+        resp = _mock_response(200, payload)
+        mock_cls, mock_http = _patch_httpx_client("post", resp)
+
+        with patch("httpx.Client", mock_cls):
+            client.submit(_SLUG, inputs={"sequence": "MKTAY"}, run_name="my-run")
+
+        call_kwargs = mock_http.post.call_args
+        sent_json = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json", {})
+        assert "inputs" in sent_json
+        assert sent_json["inputs"] == {"sequence": "MKTAY"}
+        assert sent_json.get("run_name") == "my-run"
+
+    def test_submit_with_files(self):
+        """submit(files=...) sends a multipart request (files= kwarg, not json=)."""
+        payload = {"run_id": _RUN_ID, "protocol_slug": _SLUG, "status": "scheduled"}
+        client = _make_client()
+        resp = _mock_response(200, payload)
+        mock_cls, mock_http = _patch_httpx_client("post", resp)
+
+        fake_file = io.BytesIO(b"ATOM 1 ...")
+        with patch("httpx.Client", mock_cls):
+            client.submit(_SLUG, inputs={"sequence": "MKTAY"}, files={"pdb_file": fake_file})
+
+        call_kwargs = mock_http.post.call_args
+        # Multipart uses files= not json=
+        assert call_kwargs.kwargs.get("json") is None
+        assert call_kwargs.kwargs.get("files") is not None or call_kwargs[1].get("files") is not None
+
+    def test_submit_error_response(self):
+        """submit() raises ProtocolRunError when the server returns 400."""
+        client = _make_client()
+        resp = _mock_response(400, text="invalid inputs")
+        mock_cls, _ = _patch_httpx_client("post", resp)
+
+        with patch("httpx.Client", mock_cls):
+            with pytest.raises(ProtocolRunError, match="400"):
+                client.submit(_SLUG, inputs={"bad": "field"})
+
+    # ------------------------------------------------------------------
+    # get_run()
+    # ------------------------------------------------------------------
+
+    def test_get_run_reconnects(self):
+        """get_run() returns a ProtocolRun with correct run_id and status."""
+        payload = {
+            "run_id": _RUN_ID,
+            "protocol_slug": _SLUG,
+            "protocol_version": 2,
+            "status": "succeeded",
+        }
+        client = _make_client()
+        resp = _mock_response(200, payload)
+        mock_cls, _ = _patch_httpx_client("get", resp)
+
+        with patch("httpx.Client", mock_cls):
+            run = client.get_run(_RUN_ID)
+
+        assert isinstance(run, ProtocolRun)
+        assert run.run_id == _RUN_ID
+        assert run.status == "succeeded"
+
+    # ------------------------------------------------------------------
+    # run_and_wait()
+    # ------------------------------------------------------------------
+
+    def test_run_and_wait_end_to_end(self):
+        """run_and_wait() submits, polls progress until succeeded, then returns results."""
+        client = _make_client()
+
+        submit_payload = {"run_id": _RUN_ID, "protocol_slug": _SLUG, "status": "scheduled"}
+        results_payload = {
+            "run_id": _RUN_ID,
+            "status": "succeeded",
+            "results": {"designed_sequences": ["MKTAY"]},
+        }
+
+        # We mock at the ProtocolRun level to avoid multi-layer HTTP mock complexity
+        with patch.object(ProtocolClient, "submit") as mock_submit:
+            mock_run = MagicMock(spec=ProtocolRun)
+            mock_run.wait.return_value = mock_run
+            mock_run.results.return_value = results_payload
+            mock_submit.return_value = mock_run
+
+            result = client.run_and_wait(_SLUG, inputs={"sequence": "MKTAY"}, show_progress=False)
+
+        mock_submit.assert_called_once_with(_SLUG, {"sequence": "MKTAY"}, run_name=None)
+        mock_run.wait.assert_called_once()
+        mock_run.results.assert_called_once()
+        assert result == results_payload.get("results", {})
+
+
+# ---------------------------------------------------------------------------
+# TestProtocolRun
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolRun:
+    """Tests for ProtocolRun methods: wait, progress, results, download_files, cancel, refresh."""
+
+    def _make_run(self, status: str = "scheduled") -> tuple[ProtocolRun, ProtocolClient]:
+        client = _make_client()
+        data = dict(_RUN_DATA, status=status)
+        run = ProtocolRun(data, client=client)
+        return run, client
+
+    # ------------------------------------------------------------------
+    # progress()
+    # ------------------------------------------------------------------
+
+    def test_progress_returns_dict(self):
+        """progress() calls GET /runs/{run_id}/progress/ and returns the dict."""
+        run, client = self._make_run()
+        progress_payload = {
+            "status": "running",
+            "progress_pct": 42,
+            "tasks": [],
+            "log_lines": ["starting..."],
+            "result_row_count": None,
+        }
+        resp = _mock_response(200, progress_payload)
+        mock_cls, mock_http = _patch_httpx_client("get", resp)
+
+        with patch("httpx.Client", mock_cls):
+            result = run.progress()
+
+        assert result["status"] == "running"
+        assert result["progress_pct"] == 42
+        # URL should contain 'progress'
+        called_url = mock_http.get.call_args[0][0]
+        assert "progress" in called_url
+
+    # ------------------------------------------------------------------
+    # results()
+    # ------------------------------------------------------------------
+
+    def test_results_returns_detail(self):
+        """results() calls GET /runs/{run_id}/ and returns the full detail dict."""
+        run, client = self._make_run(status="succeeded")
+        detail_payload = {
+            "run_id": _RUN_ID,
+            "status": "succeeded",
+            "results": {"output": "data"},
+            "failure_error": None,
+        }
+        resp = _mock_response(200, detail_payload)
+        mock_cls, mock_http = _patch_httpx_client("get", resp)
+
+        with patch("httpx.Client", mock_cls):
+            result = run.results()
+
+        assert result["run_id"] == _RUN_ID
+        assert result["results"] == {"output": "data"}
+        # URL must NOT contain 'progress' — it's the plain run detail endpoint
+        called_url = mock_http.get.call_args[0][0]
+        assert "progress" not in called_url
+
+    # ------------------------------------------------------------------
+    # refresh()
+    # ------------------------------------------------------------------
+
+    def test_refresh_updates_status(self):
+        """refresh() fetches run detail and updates self.status in place."""
+        run, _ = self._make_run(status="scheduled")
+        assert run.status == "scheduled"
+
+        resp = _mock_response(200, {"run_id": _RUN_ID, "status": "running"})
+        mock_cls, _ = _patch_httpx_client("get", resp)
+
+        with patch("httpx.Client", mock_cls):
+            returned = run.refresh()
+
+        assert run.status == "running"
+        assert returned is run  # returns self
+
+    # ------------------------------------------------------------------
+    # cancel()
+    # ------------------------------------------------------------------
+
+    def test_cancel_sets_status(self):
+        """cancel() calls DELETE and sets run.status = 'cancelled'."""
+        run, _ = self._make_run(status="running")
+        resp = _mock_response(200, {"detail": "cancelled"})
+        mock_cls, mock_http = _patch_httpx_client("delete", resp)
+
+        with patch("httpx.Client", mock_cls):
+            run.cancel()
+
+        assert run.status == "cancelled"
+        assert mock_http.delete.called
+
+    def test_cancel_http_error(self):
+        """cancel() raises ProtocolRunError when the server returns 400."""
+        run, _ = self._make_run(status="succeeded")
+        resp = _mock_response(400, text="already in terminal state")
+        mock_cls, _ = _patch_httpx_client("delete", resp)
+
+        with patch("httpx.Client", mock_cls):
+            with pytest.raises(ProtocolRunError, match="400"):
+                run.cancel()
+
+    # ------------------------------------------------------------------
+    # wait()
+    # ------------------------------------------------------------------
+
+    def test_wait_polls_until_succeeded(self):
+        """wait() keeps polling progress() until status is 'succeeded', then returns self."""
+        run, _ = self._make_run()
+
+        progress_calls = [
+            {"status": "running", "progress_pct": 50, "tasks": []},
+            {"status": "succeeded", "progress_pct": 100, "tasks": []},
+        ]
+
+        with patch.object(run, "progress", side_effect=progress_calls), \
+             patch("time.sleep"):
+            result = run.wait(poll_interval=0.001, show_progress=False)
+
+        assert result is run
+        assert run.status == "succeeded"
+
+    def test_wait_raises_on_failed(self):
+        """wait() raises ProtocolRunError when the run transitions to 'failed'."""
+        run, _ = self._make_run()
+
+        progress_snap = {"status": "failed", "progress_pct": None, "tasks": []}
+        detail_resp = _mock_response(200, {"run_id": _RUN_ID, "status": "failed", "failure_error": "OOM"})
+        mock_cls, _ = _patch_httpx_client("get", detail_resp)
+
+        with patch.object(run, "progress", return_value=progress_snap), \
+             patch("time.sleep"), \
+             patch("httpx.Client", mock_cls):
+            with pytest.raises(ProtocolRunError, match="failed"):
+                run.wait(poll_interval=0.001, show_progress=False)
+
+    def test_wait_raises_on_cancelled(self):
+        """wait() raises ProtocolRunError when the run is cancelled."""
+        run, _ = self._make_run()
+
+        progress_snap = {"status": "cancelled", "progress_pct": None, "tasks": []}
+
+        with patch.object(run, "progress", return_value=progress_snap), \
+             patch("time.sleep"):
+            with pytest.raises(ProtocolRunError, match="cancelled"):
+                run.wait(poll_interval=0.001, show_progress=False)
+
+    def test_wait_timeout(self):
+        """wait() raises TimeoutError when the deadline is reached before completion."""
+        run, _ = self._make_run()
+
+        # Always return 'running'
+        progress_snap = {"status": "running", "progress_pct": 10, "tasks": []}
+
+        # Use a real short timeout; patch time.sleep so the loop doesn't actually wait,
+        # but time.monotonic() must advance naturally for the deadline to trigger.
+        call_count = {"n": 0}
+
+        def fake_sleep(_):
+            call_count["n"] += 1
+            if call_count["n"] > 50:
+                # Safety valve: force time forward via monkeypatching if loop is stuck
+                raise RuntimeError("sleep called too many times in test")
+
+        with patch.object(run, "progress", return_value=progress_snap), \
+             patch("time.sleep", fake_sleep):
+            with pytest.raises(TimeoutError):
+                run.wait(poll_interval=0.0, timeout=0.0, show_progress=False)
+
+    def test_wait_no_progress_output(self, capsys):
+        """wait(show_progress=False) prints nothing to stdout."""
+        run, _ = self._make_run()
+
+        progress_calls = [
+            {"status": "running", "progress_pct": 30, "tasks": []},
+            {"status": "succeeded", "progress_pct": 100, "tasks": []},
+        ]
+
+        with patch.object(run, "progress", side_effect=progress_calls), \
+             patch("time.sleep"):
+            run.wait(poll_interval=0.001, show_progress=False)
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_wait_prints_progress(self, capsys):
+        """wait(show_progress=True) prints the run_id and progress percentage."""
+        run, _ = self._make_run()
+
+        progress_calls = [
+            {"status": "running", "progress_pct": 25, "tasks": [{"name": "step1", "status": "running"}]},
+            {"status": "succeeded", "progress_pct": 100, "tasks": []},
+        ]
+
+        with patch.object(run, "progress", side_effect=progress_calls), \
+             patch("time.sleep"):
+            run.wait(poll_interval=0.001, show_progress=True)
+
+        captured = capsys.readouterr()
+        assert _RUN_ID in captured.out
+        assert "25" in captured.out
+
+    # ------------------------------------------------------------------
+    # download_files()
+    # ------------------------------------------------------------------
+
+    def test_download_files_fetches_and_saves(self, tmp_path):
+        """download_files() fetches presigned URLs and writes files to tmp_path."""
+        run, _ = self._make_run(status="succeeded")
+
+        url_payload = {
+            "urls": {
+                "1": {
+                    "designed_pdb": {"url": "https://storage.example.com/row1_pdb.pdb"}
+                }
+            }
+        }
+
+        # First GET: download endpoint → url_payload
+        # Second GET: presigned URL → file content
+        url_resp = _mock_response(200, url_payload)
+        file_content = b"ATOM 1 CA ALA A 1 ..."
+        file_resp = _mock_response(200, content=file_content)
+
+        mock_cls = MagicMock()
+        mock_http = MagicMock()
+        mock_cls.return_value.__enter__.return_value = mock_http
+        mock_cls.return_value.__exit__.return_value = False
+
+        # _get() opens one httpx.Client; download_files() opens another httpx.Client
+        # Both are patched via the same mock_cls but we need sequential return values.
+        mock_http.get.side_effect = [url_resp, file_resp]
+
+        with patch("httpx.Client", mock_cls):
+            paths = run.download_files(output_dir=str(tmp_path), columns=["designed_pdb"])
+
+        assert len(paths) == 1
+        dest = tmp_path / "1_designed_pdb.pdb"
+        assert dest.exists()
+        assert dest.read_bytes() == file_content
+
+    def test_download_files_skips_existing(self, tmp_path):
+        """download_files(overwrite=False) does not re-download an existing file."""
+        run, _ = self._make_run(status="succeeded")
+
+        # Pre-create the file that would be downloaded
+        existing = tmp_path / "1_designed_pdb.pdb"
+        existing.write_bytes(b"already-here")
+
+        url_payload = {
+            "urls": {
+                "1": {
+                    "designed_pdb": {"url": "https://storage.example.com/row1_pdb.pdb"}
+                }
+            }
+        }
+        url_resp = _mock_response(200, url_payload)
+
+        mock_cls = MagicMock()
+        mock_http = MagicMock()
+        mock_cls.return_value.__enter__.return_value = mock_http
+        mock_cls.return_value.__exit__.return_value = False
+        mock_http.get.return_value = url_resp
+
+        with patch("httpx.Client", mock_cls):
+            paths = run.download_files(output_dir=str(tmp_path), overwrite=False)
+
+        # File not re-downloaded: get called once (for URL list) not twice
+        assert mock_http.get.call_count == 1
+        assert existing in paths
+        assert existing.read_bytes() == b"already-here"
+
+    def test_download_files_empty_urls(self, tmp_path):
+        """download_files() returns [] when the API returns an empty urls dict."""
+        run, _ = self._make_run(status="succeeded")
+
+        url_payload = {"urls": {}}
+        url_resp = _mock_response(200, url_payload)
+
+        mock_cls = MagicMock()
+        mock_http = MagicMock()
+        mock_cls.return_value.__enter__.return_value = mock_http
+        mock_cls.return_value.__exit__.return_value = False
+        mock_http.get.return_value = url_resp
+
+        with patch("httpx.Client", mock_cls):
+            paths = run.download_files(output_dir=str(tmp_path))
+
+        assert paths == []
+
+
+# ---------------------------------------------------------------------------
+# TestTopLevel
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevel:
+    """Tests for the top-level biolmai.run_protocol() convenience function."""
+
+    def test_top_level_convenience(self, monkeypatch):
+        """run_protocol() builds a ProtocolClient, calls run_and_wait, returns results."""
+        import biolmai
+
+        monkeypatch.setenv("BIOLMAI_TOKEN", _TOKEN)
+
+        expected_results = {"designed_sequences": ["MKTAY", "MKLAY"]}
+
+        with patch.object(ProtocolClient, "run_and_wait", return_value=expected_results) as mock_raw:
+            result = biolmai.run_protocol(
+                _SLUG,
+                inputs={"sequence": "MKTAY"},
+                run_name="top-level-test",
+                api_key=_TOKEN,
+                show_progress=False,
+            )
+
+        assert result == expected_results
+        mock_raw.assert_called_once_with(
+            _SLUG,
+            {"sequence": "MKTAY"},
+            run_name="top-level-test",
+            poll_interval=5.0,
+            timeout=3600.0,
+            show_progress=False,
+        )

--- a/tests/test_protocol_client.py
+++ b/tests/test_protocol_client.py
@@ -24,6 +24,7 @@ Tests are grouped into three classes:
 import io
 import os
 import time
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
@@ -452,6 +453,20 @@ class TestProtocolRun:
     # wait()
     # ------------------------------------------------------------------
 
+    def test_wait_already_terminal_skips_ws(self):
+        """wait() does not call _listen_ws() when run is already in a terminal state at entry."""
+        run, _ = self._make_run()
+
+        progress_snap = {"status": "succeeded", "channel_id": "telemetry_abc"}
+
+        with patch.object(run, "progress", return_value=progress_snap), \
+             patch.object(run, "_listen_ws") as mock_ws:
+            result = run.wait(show_progress=False)
+
+        mock_ws.assert_not_called()
+        assert result is run
+        assert run.status == "succeeded"
+
     def test_wait_via_ws_until_succeeded(self):
         """wait() calls progress() once for channel_id, then _listen_ws(), returns self."""
         run, _ = self._make_run()
@@ -542,6 +557,45 @@ class TestProtocolRun:
         captured = capsys.readouterr()
         assert _RUN_ID in captured.out
         assert "25" in captured.out
+
+    # ------------------------------------------------------------------
+    # to_dataframe()
+    # ------------------------------------------------------------------
+
+    def test_to_dataframe_happy_path(self, tmp_path):
+        """to_dataframe() downloads the zip, parses the CSV, and returns a DataFrame."""
+        run, _ = self._make_run(status="succeeded")
+        zip_path = tmp_path / f"{_RUN_ID}_results.csv.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("results.csv", "sequence,score\nMKTAY,0.9\nMKLAY,0.7\n")
+
+        with patch.object(run, "download", return_value=zip_path):
+            df = run.to_dataframe(output_dir=str(tmp_path))
+
+        assert list(df.columns) == ["sequence", "score"]
+        assert len(df) == 2
+        assert df["sequence"].tolist() == ["MKTAY", "MKLAY"]
+
+    def test_to_dataframe_no_pandas(self, tmp_path):
+        """to_dataframe() raises ImportError with helpful message when pandas is missing."""
+        import sys
+
+        run, _ = self._make_run(status="succeeded")
+
+        with patch.dict(sys.modules, {"pandas": None}):
+            with pytest.raises(ImportError, match="pandas"):
+                run.to_dataframe(output_dir=str(tmp_path))
+
+    def test_to_dataframe_no_csv_in_zip(self, tmp_path):
+        """to_dataframe() raises ProtocolRunError when the zip contains no CSV file."""
+        run, _ = self._make_run(status="succeeded")
+        zip_path = tmp_path / f"{_RUN_ID}_results.csv.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("results.jsonl", '{"sequence": "MKTAY"}\n')
+
+        with patch.object(run, "download", return_value=zip_path):
+            with pytest.raises(ProtocolRunError, match="No CSV"):
+                run.to_dataframe(output_dir=str(tmp_path))
 
     # ------------------------------------------------------------------
     # download_files() — simple alias for download()

--- a/tests/test_protocol_client.py
+++ b/tests/test_protocol_client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Tests for ProtocolClient, ProtocolRun, and the top-level run_protocol() function.
 
 HTTP calls are mocked entirely via unittest.mock.patch on httpx.Client so no real

--- a/tests/test_protocol_client.py
+++ b/tests/test_protocol_client.py
@@ -8,6 +8,13 @@ a context manager, so the mock hierarchy is:
     mock_http.get.return_value   / .post.return_value / .delete.return_value
         .status_code, .is_success, .text, .json(), .content
 
+Integration tests (bottom of file):
+    TestProtocolClientIntegration — hits a real BioLM server with a real token.
+    Skipped unless BIOLMAI_TOKEN and BIOLMAI_BASE_DOMAIN are set.
+    Run with:
+        BIOLMAI_TOKEN=sk-... BIOLMAI_BASE_DOMAIN=http://localhost:7777 \\
+            pytest tests/test_protocol_client.py::TestProtocolClientIntegration -v
+
 Tests are grouped into three classes:
     TestProtocolClient  — auth + list / get / submit / get_run / run_and_wait
     TestProtocolRun     — wait / progress / results / download_files / cancel / refresh
@@ -445,189 +452,111 @@ class TestProtocolRun:
     # wait()
     # ------------------------------------------------------------------
 
-    def test_wait_polls_until_succeeded(self):
-        """wait() keeps polling progress() until status is 'succeeded', then returns self."""
+    def test_wait_via_ws_until_succeeded(self):
+        """wait() calls progress() once for channel_id, then _listen_ws(), returns self."""
         run, _ = self._make_run()
 
-        progress_calls = [
-            {"status": "running", "progress_pct": 50, "tasks": []},
-            {"status": "succeeded", "progress_pct": 100, "tasks": []},
-        ]
+        progress_snap = {"status": "running", "progress_pct": 50, "channel_id": "telemetry_abc"}
 
-        with patch.object(run, "progress", side_effect=progress_calls), \
-             patch("time.sleep"):
-            result = run.wait(poll_interval=0.001, show_progress=False)
+        def fake_listen(ws_url, show_progress=True, timeout=3600.0):
+            run.status = "succeeded"
+
+        with patch.object(run, "progress", return_value=progress_snap), \
+             patch.object(run, "_listen_ws", side_effect=fake_listen):
+            result = run.wait(show_progress=False)
 
         assert result is run
         assert run.status == "succeeded"
 
     def test_wait_raises_on_failed(self):
-        """wait() raises ProtocolRunError when the run transitions to 'failed'."""
+        """wait() raises ProtocolRunError when progress() returns a failed status."""
         run, _ = self._make_run()
 
-        progress_snap = {"status": "failed", "progress_pct": None, "tasks": []}
+        progress_snap = {"status": "failed", "channel_id": "telemetry_abc"}
         detail_resp = _mock_response(200, {"run_id": _RUN_ID, "status": "failed", "failure_error": "OOM"})
         mock_cls, _ = _patch_httpx_client("get", detail_resp)
 
         with patch.object(run, "progress", return_value=progress_snap), \
-             patch("time.sleep"), \
              patch("httpx.Client", mock_cls):
             with pytest.raises(ProtocolRunError, match="failed"):
-                run.wait(poll_interval=0.001, show_progress=False)
+                run.wait(show_progress=False)
 
     def test_wait_raises_on_cancelled(self):
-        """wait() raises ProtocolRunError when the run is cancelled."""
+        """wait() raises ProtocolRunError when progress() returns a cancelled status."""
         run, _ = self._make_run()
 
-        progress_snap = {"status": "cancelled", "progress_pct": None, "tasks": []}
+        progress_snap = {"status": "cancelled", "channel_id": "telemetry_abc"}
 
-        with patch.object(run, "progress", return_value=progress_snap), \
-             patch("time.sleep"):
+        with patch.object(run, "progress", return_value=progress_snap):
             with pytest.raises(ProtocolRunError, match="cancelled"):
-                run.wait(poll_interval=0.001, show_progress=False)
+                run.wait(show_progress=False)
 
-    def test_wait_timeout(self):
-        """wait() raises TimeoutError when the deadline is reached before completion."""
+    def test_wait_ws_loss_raises(self):
+        """wait() raises ProtocolRunError if _listen_ws raises before terminal status."""
         run, _ = self._make_run()
 
-        # Always return 'running'
-        progress_snap = {"status": "running", "progress_pct": 10, "tasks": []}
+        progress_snap = {"status": "running", "channel_id": "telemetry_abc"}
 
-        # Use a real short timeout; patch time.sleep so the loop doesn't actually wait,
-        # but time.monotonic() must advance naturally for the deadline to trigger.
-        call_count = {"n": 0}
-
-        def fake_sleep(_):
-            call_count["n"] += 1
-            if call_count["n"] > 50:
-                # Safety valve: force time forward via monkeypatching if loop is stuck
-                raise RuntimeError("sleep called too many times in test")
+        def fake_listen(ws_url, show_progress=True, timeout=3600.0):
+            raise ProtocolRunError(
+                f"WebSocket connection lost for run {run.run_id}: connection refused. "
+                "Last known status: running"
+            )
 
         with patch.object(run, "progress", return_value=progress_snap), \
-             patch("time.sleep", fake_sleep):
-            with pytest.raises(TimeoutError):
-                run.wait(poll_interval=0.0, timeout=0.0, show_progress=False)
+             patch.object(run, "_listen_ws", side_effect=fake_listen):
+            with pytest.raises(ProtocolRunError, match="WebSocket connection lost"):
+                run.wait(show_progress=False)
 
     def test_wait_no_progress_output(self, capsys):
         """wait(show_progress=False) prints nothing to stdout."""
         run, _ = self._make_run()
 
-        progress_calls = [
-            {"status": "running", "progress_pct": 30, "tasks": []},
-            {"status": "succeeded", "progress_pct": 100, "tasks": []},
-        ]
+        progress_snap = {"status": "running", "channel_id": "telemetry_abc"}
 
-        with patch.object(run, "progress", side_effect=progress_calls), \
-             patch("time.sleep"):
-            run.wait(poll_interval=0.001, show_progress=False)
+        def fake_listen(ws_url, show_progress=True, timeout=3600.0):
+            run.status = "succeeded"
+
+        with patch.object(run, "progress", return_value=progress_snap), \
+             patch.object(run, "_listen_ws", side_effect=fake_listen):
+            run.wait(show_progress=False)
 
         captured = capsys.readouterr()
         assert captured.out == ""
 
     def test_wait_prints_progress(self, capsys):
-        """wait(show_progress=True) prints the run_id and progress percentage."""
+        """wait(show_progress=True) passes show_progress=True into _listen_ws."""
         run, _ = self._make_run()
 
-        progress_calls = [
-            {"status": "running", "progress_pct": 25, "tasks": [{"name": "step1", "status": "running"}]},
-            {"status": "succeeded", "progress_pct": 100, "tasks": []},
-        ]
+        progress_snap = {"status": "running", "progress_pct": 25, "channel_id": "telemetry_abc"}
 
-        with patch.object(run, "progress", side_effect=progress_calls), \
-             patch("time.sleep"):
-            run.wait(poll_interval=0.001, show_progress=True)
+        def fake_listen(ws_url, show_progress=True, timeout=3600.0):
+            if show_progress:
+                print(f"  [{run.run_id}] running 25%")
+            run.status = "succeeded"
+
+        with patch.object(run, "progress", return_value=progress_snap), \
+             patch.object(run, "_listen_ws", side_effect=fake_listen):
+            run.wait(show_progress=True)
 
         captured = capsys.readouterr()
         assert _RUN_ID in captured.out
         assert "25" in captured.out
 
     # ------------------------------------------------------------------
-    # download_files()
+    # download_files() — simple alias for download()
     # ------------------------------------------------------------------
 
-    def test_download_files_fetches_and_saves(self, tmp_path):
-        """download_files() fetches presigned URLs and writes files to tmp_path."""
+    def test_download_files_is_alias_for_download(self, tmp_path):
+        """download_files() calls download() with the same args and returns its result."""
         run, _ = self._make_run(status="succeeded")
+        expected_path = tmp_path / f"{_RUN_ID}_results.csv.zip"
 
-        url_payload = {
-            "urls": {
-                "1": {
-                    "designed_pdb": {"url": "https://storage.example.com/row1_pdb.pdb"}
-                }
-            }
-        }
+        with patch.object(run, "download", return_value=expected_path) as mock_dl:
+            result = run.download_files(output_dir=str(tmp_path), file_type="csv", overwrite=False)
 
-        # First GET: download endpoint → url_payload
-        # Second GET: presigned URL → file content
-        url_resp = _mock_response(200, url_payload)
-        file_content = b"ATOM 1 CA ALA A 1 ..."
-        file_resp = _mock_response(200, content=file_content)
-
-        mock_cls = MagicMock()
-        mock_http = MagicMock()
-        mock_cls.return_value.__enter__.return_value = mock_http
-        mock_cls.return_value.__exit__.return_value = False
-
-        # _get() opens one httpx.Client; download_files() opens another httpx.Client
-        # Both are patched via the same mock_cls but we need sequential return values.
-        mock_http.get.side_effect = [url_resp, file_resp]
-
-        with patch("httpx.Client", mock_cls):
-            paths = run.download_files(output_dir=str(tmp_path), columns=["designed_pdb"])
-
-        assert len(paths) == 1
-        dest = tmp_path / "1_designed_pdb.pdb"
-        assert dest.exists()
-        assert dest.read_bytes() == file_content
-
-    def test_download_files_skips_existing(self, tmp_path):
-        """download_files(overwrite=False) does not re-download an existing file."""
-        run, _ = self._make_run(status="succeeded")
-
-        # Pre-create the file that would be downloaded
-        existing = tmp_path / "1_designed_pdb.pdb"
-        existing.write_bytes(b"already-here")
-
-        url_payload = {
-            "urls": {
-                "1": {
-                    "designed_pdb": {"url": "https://storage.example.com/row1_pdb.pdb"}
-                }
-            }
-        }
-        url_resp = _mock_response(200, url_payload)
-
-        mock_cls = MagicMock()
-        mock_http = MagicMock()
-        mock_cls.return_value.__enter__.return_value = mock_http
-        mock_cls.return_value.__exit__.return_value = False
-        mock_http.get.return_value = url_resp
-
-        with patch("httpx.Client", mock_cls):
-            paths = run.download_files(output_dir=str(tmp_path), overwrite=False)
-
-        # File not re-downloaded: get called once (for URL list) not twice
-        assert mock_http.get.call_count == 1
-        assert existing in paths
-        assert existing.read_bytes() == b"already-here"
-
-    def test_download_files_empty_urls(self, tmp_path):
-        """download_files() returns [] when the API returns an empty urls dict."""
-        run, _ = self._make_run(status="succeeded")
-
-        url_payload = {"urls": {}}
-        url_resp = _mock_response(200, url_payload)
-
-        mock_cls = MagicMock()
-        mock_http = MagicMock()
-        mock_cls.return_value.__enter__.return_value = mock_http
-        mock_cls.return_value.__exit__.return_value = False
-        mock_http.get.return_value = url_resp
-
-        with patch("httpx.Client", mock_cls):
-            paths = run.download_files(output_dir=str(tmp_path))
-
-        assert paths == []
+        mock_dl.assert_called_once_with(output_dir=str(tmp_path), file_type="csv", overwrite=False)
+        assert result == expected_path
 
 
 # ---------------------------------------------------------------------------
@@ -664,3 +593,195 @@ class TestTopLevel:
             timeout=3600.0,
             show_progress=False,
         )
+
+
+# ===========================================================================
+# Integration tests — skipped unless BIOLMAI_TOKEN is set
+#
+# These make REAL HTTP requests to a live BioLM server (local or prod).
+# No mocking. The full client → server → Celery → Modal → results path is
+# exercised.
+#
+# Usage (against local dev stack):
+#   BIOLMAI_TOKEN=your-token BIOLMAI_BASE_DOMAIN=http://localhost:7777 \
+#       pytest tests/test_protocol_client.py::TestProtocolClientIntegration -v
+#
+# Usage (against prod):
+#   BIOLMAI_TOKEN=your-token \
+#       pytest tests/test_protocol_client.py::TestProtocolClientIntegration -v
+#
+# Required env vars:
+#   BIOLMAI_TOKEN              — Knox API token for an account with protocol access
+#   BIOLMAI_BASE_DOMAIN        — base URL (default: https://biolm.ai)
+#
+# Optional env vars:
+#   INTEGRATION_PROTOCOL_SLUG  — protocol slug to test (default: test-echo-protocol)
+#   INTEGRATION_POLL_TIMEOUT   — max seconds to wait for completion (default: 300)
+# ===========================================================================
+
+import os
+import pytest
+
+
+def _integration_enabled():
+    """Both an explicit opt-in flag AND a token must be present."""
+    has_token = bool(os.environ.get("BIOLMAI_TOKEN") or os.environ.get("BIOLM_TOKEN"))
+    opted_in = os.environ.get("BIOLMAI_INTEGRATION") == "1"
+    return has_token and opted_in
+
+
+@pytest.mark.skipif(
+    not _integration_enabled(),
+    reason="Skipped: set BIOLMAI_TOKEN and BIOLMAI_INTEGRATION=1 to run against a live server",
+)
+class TestProtocolClientIntegration:
+    """End-to-end integration tests using a real ProtocolClient against a live server.
+
+    No HTTP mocking. Tests submit real protocol runs, poll /progress/ until
+    terminal, and verify results are returned. Requires biolm_web PR #161 to
+    be merged and the target protocol to be published.
+    """
+
+    _SLUG = os.environ.get("INTEGRATION_PROTOCOL_SLUG", "test-echo-protocol")
+    _TIMEOUT = int(os.environ.get("INTEGRATION_POLL_TIMEOUT", 300))
+
+    @pytest.fixture(autouse=True)
+    def client(self):
+        from biolmai import ProtocolClient
+        base_url = os.environ.get("BIOLMAI_BASE_DOMAIN")
+        kwargs = {"api_key": _integration_token()}
+        if base_url:
+            kwargs["base_url"] = base_url
+        self._client = ProtocolClient(**kwargs)
+
+    def test_list_returns_results(self):
+        """client.list() hits the real server and returns a valid paginated response."""
+        result = self._client.list()
+        assert "results" in result
+        assert "count" in result
+        assert isinstance(result["results"], list)
+
+    def test_get_protocol_schema(self):
+        """client.get(slug) returns inputs_schema for the target protocol.
+
+        Skip gracefully if the protocol doesn't exist on this server.
+        """
+        from biolmai import ProtocolNotFoundError
+        try:
+            schema = self._client.get(self._SLUG)
+        except ProtocolNotFoundError:
+            pytest.skip(
+                f"Protocol '{self._SLUG}' not found on this server. "
+                "Publish it via the console or set INTEGRATION_PROTOCOL_SLUG."
+            )
+        assert "inputs_schema" in schema
+        assert schema["slug"] == self._SLUG
+
+    def test_submit_and_wait_for_completion(self):
+        """Submit a real run and poll until succeeded. Verify results are populated.
+
+        Uses the protocol's own inputs_schema to build minimal valid inputs,
+        so this test stays protocol-agnostic.
+        """
+        from biolmai import ProtocolNotFoundError, ProtocolRunError
+
+        # Fetch schema to build inputs
+        try:
+            schema = self._client.get(self._SLUG)
+        except ProtocolNotFoundError:
+            pytest.skip(f"Protocol '{self._SLUG}' not found — cannot submit.")
+
+        # Build minimal inputs: use initial/default values from schema where available,
+        # otherwise skip required fields that have no default (test will fail clearly)
+        inputs = {}
+        for field, spec in schema.get("inputs_schema", {}).items():
+            if "initial" in spec:
+                inputs[field] = spec["initial"]
+            elif spec.get("required"):
+                pytest.skip(
+                    f"Required field '{field}' has no default — provide a test protocol "
+                    "with example_inputs or set INTEGRATION_PROTOCOL_SLUG to one that does."
+                )
+
+        # Submit
+        run = self._client.submit(self._SLUG, inputs=inputs, run_name="sdk-integration-test")
+        assert run.run_id.startswith("ALY_"), f"Unexpected run_id: {run.run_id}"
+        assert run.status in ("scheduled", "running")
+
+        # Wait for completion
+        try:
+            run.wait(poll_interval=5, timeout=self._TIMEOUT, show_progress=True)
+        except ProtocolRunError as exc:
+            pytest.fail(f"Run {run.run_id} failed: {exc}")
+
+        assert run.status == "succeeded"
+
+        # Verify results
+        detail = run.results()
+        assert detail["status"] == "succeeded"
+        assert detail.get("results") is not None, (
+            f"Run {run.run_id} succeeded but results is null — "
+            "protocol may not be writing return_json."
+        )
+
+    def test_progress_shape_during_run(self):
+        """Progress endpoint returns correctly shaped data for a live run."""
+        from biolmai import ProtocolNotFoundError
+
+        try:
+            schema = self._client.get(self._SLUG)
+        except ProtocolNotFoundError:
+            pytest.skip(f"Protocol '{self._SLUG}' not found.")
+
+        inputs = {
+            field: spec["initial"]
+            for field, spec in schema.get("inputs_schema", {}).items()
+            if "initial" in spec
+        }
+
+        run = self._client.submit(self._SLUG, inputs=inputs)
+
+        # Poll once immediately — run may be scheduled or already running
+        prog = run.progress()
+        assert "status" in prog
+        assert "tasks" in prog
+        assert "log_lines" in prog
+        assert "progress_pct" in prog
+        assert isinstance(prog["tasks"], list)
+        assert isinstance(prog["log_lines"], list)
+
+        # Clean up — wait or cancel
+        if prog["status"] not in ("succeeded", "failed", "cancelled"):
+            try:
+                run.wait(poll_interval=5, timeout=self._TIMEOUT, show_progress=False)
+            except Exception:
+                run.cancel()
+
+    def test_get_run_reconnect(self):
+        """client.get_run(run_id) reconnects to a prior run and returns current status."""
+        from biolmai import ProtocolNotFoundError
+
+        try:
+            schema = self._client.get(self._SLUG)
+        except ProtocolNotFoundError:
+            pytest.skip(f"Protocol '{self._SLUG}' not found.")
+
+        inputs = {
+            field: spec["initial"]
+            for field, spec in schema.get("inputs_schema", {}).items()
+            if "initial" in spec
+        }
+
+        # Submit, then reconnect by run_id
+        original = self._client.submit(self._SLUG, inputs=inputs)
+        run_id = original.run_id
+
+        reconnected = self._client.get_run(run_id)
+        assert reconnected.run_id == run_id
+        assert reconnected.status in ("scheduled", "running", "succeeded", "failed", "cancelled")
+
+        # Clean up
+        try:
+            reconnected.wait(poll_interval=5, timeout=self._TIMEOUT, show_progress=False)
+        except Exception:
+            reconnected.cancel()

--- a/tests/test_protocol_client.py
+++ b/tests/test_protocol_client.py
@@ -643,7 +643,6 @@ class TestTopLevel:
             _SLUG,
             {"sequence": "MKTAY"},
             run_name="top-level-test",
-            poll_interval=5.0,
             timeout=3600.0,
             show_progress=False,
         )
@@ -764,7 +763,7 @@ class TestProtocolClientIntegration:
 
         # Wait for completion
         try:
-            run.wait(poll_interval=5, timeout=self._TIMEOUT, show_progress=True)
+            run.wait(timeout=self._TIMEOUT, show_progress=True)
         except ProtocolRunError as exc:
             pytest.fail(f"Run {run.run_id} failed: {exc}")
 
@@ -807,7 +806,7 @@ class TestProtocolClientIntegration:
         # Clean up — wait or cancel
         if prog["status"] not in ("succeeded", "failed", "cancelled"):
             try:
-                run.wait(poll_interval=5, timeout=self._TIMEOUT, show_progress=False)
+                run.wait(timeout=self._TIMEOUT, show_progress=False)
             except Exception:
                 run.cancel()
 
@@ -836,6 +835,6 @@ class TestProtocolClientIntegration:
 
         # Clean up
         try:
-            reconnected.wait(poll_interval=5, timeout=self._TIMEOUT, show_progress=False)
+            reconnected.wait(timeout=self._TIMEOUT, show_progress=False)
         except Exception:
             reconnected.cancel()


### PR DESCRIPTION
## Summary

Adds `ProtocolClient` and `ProtocolRun` to the SDK, backed by the new `/api/protocols/` REST API.

## New public API

### `ProtocolClient`

```python
from biolmai import ProtocolClient

client = ProtocolClient()  # reads BIOLMAI_TOKEN from env

# Discover what protocols are available
client.list(search="antibody")

# Inspect required inputs before submitting
schema = client.get("antibody-optimization")
print(schema["inputs_schema"])

# Submit a run (non-blocking)
run = client.submit(
    "antibody-optimization",
    inputs={"sequence": "MKTAYIAKQRQ", "n_rounds": 3},
    run_name="experiment v7",
)

# Block until complete with live progress output
run.wait()

# Fetch results
print(run.results())

# Download structure files (PDB/CIF) to disk
paths = run.download_files("./structures", columns=["designed_pdb"], rows=[1, 2, 3])

# Cancel a running job
run.cancel()

# Reconnect to a prior run in a later session
run = client.get_run("ALY_507f1f77bcf86cd799439011")
```

### `run_protocol` — one-liner

```python
import biolmai

results = biolmai.run_protocol(
    "antibody-optimization",
    inputs={"sequence": "MKTAYIAKQRQ", "n_rounds": 3},
)
```

### `ProtocolRun` methods

| Method | Description |
|--------|-------------|
| `.wait(poll_interval, timeout, show_progress)` | Block until terminal state |
| `.progress()` | Live snapshot: `status`, `progress_pct`, `tasks`, `log_lines`, `result_row_count` |
| `.log_lines()` | Latest log lines from the run |
| `.results()` | Full run detail including `results` payload |
| `.download(format="json"\|"urls")` | Raw download response |
| `.download_files(output_dir, columns, rows, overwrite)` | Fetch presigned URLs + save PDB/CIF to disk |
| `.cancel()` | Cancel scheduled/running run |
| `.refresh()` | Update `self.status` from API |

## API endpoints used

| Endpoint | Purpose |
|----------|---------|
| `GET /api/protocols/` | `client.list()` |
| `GET /api/protocols/{slug}/` | `client.get()` |
| `POST /api/protocols/{slug}/runs/` | `client.submit()` |
| `GET /api/protocols/runs/` | `client.runs()` |
| `GET /api/protocols/runs/{run_id}/` | `run.results()` |
| `GET /api/protocols/runs/{run_id}/progress/` | `run.progress()`, `run.wait()` |
| `GET /api/protocols/runs/{run_id}/download/` | `run.download()`, `run.download_files()` |
| `DELETE /api/protocols/runs/{run_id}/cancel/` | `run.cancel()` |

## Test plan

- [ ] `ProtocolClient()` raises `ValueError` with clear message when no token set
- [ ] `client.list()` returns paginated results
- [ ] `client.get("nonexistent-slug")` raises `ProtocolNotFoundError`
- [ ] `client.submit()` returns a `ProtocolRun` with a valid `run_id`
- [ ] `run.wait()` prints progress updates and returns `self` on success
- [ ] `run.wait()` raises `ProtocolRunError` for failed/cancelled runs
- [ ] `run.wait()` raises `TimeoutError` when timeout exceeded
- [ ] `run.download_files()` creates local files from presigned URLs
- [ ] `biolmai.run_protocol()` one-liner returns results dict
- [ ] `client.get_run(run_id)` reconnects to a prior run
- [ ] `base_url="http://localhost:7777"` routes to local dev server