### PR TITLE
feat(finetune): SDK client for programmatic finetuning

### DIFF
--- a/biolmai/__init__.py
+++ b/biolmai/__init__.py
@@ -7,6 +7,7 @@ from biolmai.core.http import BioLMApi, BioLMApiClient
 from biolmai.biolmai import BioLM
 from biolmai.models import Model, predict, encode, generate
 from biolmai.protocols import Protocol
+from biolmai.finetune import Finetune
 from biolmai.workspaces import Workspace
 from biolmai.volumes import Volume
 from biolmai.examples import get_example, list_models
@@ -41,6 +42,7 @@ __all__ = [
     # New interfaces from issue49
     'Model',
     'Protocol',
+    'Finetune',
     'Workspace',
     'Volume',
     # Convenience functions

--- a/biolmai/finetune.py
+++ b/biolmai/finetune.py
@@ -1,0 +1,458 @@
+"""Programmatic finetuning client for BioLM.
+
+Wraps the ``/api/finetune/`` endpoints (the SDK-facing companion to the browser
+console finetuning UI) so callers can launch and track XGBoost and DSM
+finetuning runs from Python without a session cookie.
+
+Auth follows the same rules as the rest of the SDK: pass ``api_key=`` or set
+``BIOLMAI_TOKEN`` / ``BIOLM_TOKEN`` (see :class:`biolmai.core.http.CredentialsProvider`).
+
+Example
+-------
+>>> from biolmai import Finetune
+>>> run = Finetune.xgboost(
+...     train_data=[{"sequence": "EVQLVESGGG", "label": 0},
+...                 {"sequence": "QVQLVQSGAE", "label": 1}],
+...     embedding_models=["esm2-8m"],
+...     task_type="classification",
+...     hyperopt=True,
+...     hyperopt_n_trials=20,
+... )
+>>> run["run_id"]
+'ALY_...'
+>>> Finetune.progress(run["run_id"])["status"]
+'running'
+"""
+import asyncio
+import time
+from typing import Any, Dict, List, Optional, Union
+
+# Terminal run states — used by :meth:`Finetune.wait`.
+TERMINAL_STATUSES = {"succeeded", "failed", "cancelled", "error"}
+
+Rows = Union[List[Dict[str, Any]], str]
+
+
+def _run_sync(coro):
+    """Run *coro* to completion whether or not an event loop is active.
+
+    Mirrors :meth:`biolmai.protocols.Protocol.fetch_by_id` so the finetune
+    helpers are usable from scripts, notebooks, and async code alike.
+    """
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                return executor.submit(asyncio.run, coro).result()
+        return loop.run_until_complete(coro)
+    except RuntimeError:
+        return asyncio.run(coro)
+
+
+def _base_url() -> str:
+    """Resolve the ``/api/finetune`` base from the configured BioLM domain."""
+    from biolmai.core.const import BIOLMAI_BASE_DOMAIN
+
+    return f"{BIOLMAI_BASE_DOMAIN.rstrip('/')}/api/finetune"
+
+
+def _client(api_key: Optional[str], base_url: Optional[str]):
+    """Build an :class:`HttpClient` pointed at the finetune API."""
+    import httpx
+
+    from biolmai.core.http import CredentialsProvider, HttpClient
+
+    final_base = base_url if base_url is not None else _base_url()
+    headers = CredentialsProvider.get_auth_headers(api_key)
+    timeout = httpx.Timeout(60.0, connect=10.0)
+    return HttpClient(final_base, headers, timeout)
+
+
+def _raise_for_status(resp, action: str):
+    """Translate an error response into a Python exception, mirroring protocols.py."""
+    if resp.status_code == 401:
+        raise PermissionError(
+            "Authentication required. Set BIOLMAI_TOKEN (or BIOLM_TOKEN) "
+            "or run `biolmai login`."
+        )
+    if resp.status_code == 402:
+        raise PermissionError(
+            "Finetuning is not enabled for this account. "
+            "Contact BioLM to enable finetuning."
+        )
+    if resp.status_code == 404:
+        raise FileNotFoundError(f"Run not found while trying to {action}.")
+    if resp.status_code >= 400:
+        detail = resp.text
+        try:
+            body = resp.json()
+            detail = body.get("error") or body.get("detail") or body.get("errors") or detail
+        except Exception:
+            pass
+        raise ValueError(f"Failed to {action}: {detail} (status {resp.status_code})")
+
+
+async def _post(endpoint: str, payload: dict, api_key, base_url, action: str) -> dict:
+    client = _client(api_key, base_url)
+    try:
+        resp = await client.post(endpoint, payload)
+        _raise_for_status(resp, action)
+        return resp.json()
+    finally:
+        await client.close()
+
+
+async def _get(endpoint: str, api_key, base_url, action: str) -> dict:
+    client = _client(api_key, base_url)
+    try:
+        resp = await client.get(endpoint)
+        _raise_for_status(resp, action)
+        return resp.json()
+    finally:
+        await client.close()
+
+
+async def _delete(endpoint: str, api_key, base_url, action: str) -> dict:
+    client = _client(api_key, base_url)
+    try:
+        # HttpClient exposes get/post; reach the shared async client for DELETE.
+        http = await client.get_async_client()
+        endpoint = endpoint.lstrip("/")
+        if not endpoint.endswith("/"):
+            endpoint += "/"
+        resp = await http.delete(endpoint)
+        _raise_for_status(resp, action)
+        return resp.json()
+    finally:
+        await client.close()
+
+
+def _drop_none(d: dict) -> dict:
+    """Strip keys whose value is ``None`` so server-side defaults apply."""
+    return {k: v for k, v in d.items() if v is not None}
+
+
+class Finetune:
+    """Launch and track BioLM finetuning runs.
+
+    All methods are classmethods returning plain dicts. ``*_data`` arguments
+    accept a list of row dicts (``[{"sequence": ..., "label": ...}, ...]``) or a
+    raw CSV string; they are sent inline as JSON.
+    """
+
+    # -- XGBoost ----------------------------------------------------------
+
+    @classmethod
+    async def xgboost_async(
+        cls,
+        *,
+        train_data: Rows,
+        embedding_models: List[str],
+        task_type: str = "classification",
+        target_column: str = "label",
+        text_column: str = "sequence",
+        test_data: Optional[Rows] = None,
+        validation_data: Optional[Rows] = None,
+        n_estimators: int = 100,
+        max_depth: int = 6,
+        learning_rate: float = 0.1,
+        n_splits: int = 5,
+        seed: int = 42,
+        hyperopt: bool = False,
+        hyperopt_n_trials: Optional[int] = None,
+        antibody_mode: bool = False,
+        heavy_column: str = "heavy",
+        light_column: str = "light",
+        modality: str = "protein",
+        run_name: Optional[str] = None,
+        environment_id: Optional[Union[int, str]] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> dict:
+        """Launch an XGBoost finetune (optionally with Ray Tune hyperopt)."""
+        payload = _drop_none(
+            {
+                "run_name": run_name,
+                "task_type": task_type,
+                "target_column": target_column,
+                "text_column": text_column,
+                "embedding_models": list(embedding_models),
+                "train_data": train_data,
+                "test_data": test_data,
+                "validation_data": validation_data,
+                "n_estimators": n_estimators,
+                "max_depth": max_depth,
+                "learning_rate": learning_rate,
+                "n_splits": n_splits,
+                "seed": seed,
+                "hyperopt": hyperopt,
+                "hyperopt_n_trials": hyperopt_n_trials,
+                "antibody_mode": antibody_mode,
+                "heavy_column": heavy_column,
+                "light_column": light_column,
+                "modality": modality,
+                "environment_id": environment_id,
+            }
+        )
+        return await _post("xgboost/runs/", payload, api_key, base_url, "create XGBoost run")
+
+    @classmethod
+    def xgboost(cls, **kwargs) -> dict:
+        """Synchronous wrapper for :meth:`xgboost_async`."""
+        return _run_sync(cls.xgboost_async(**kwargs))
+
+    # -- DSM Stage 1 ------------------------------------------------------
+
+    @classmethod
+    async def dsm_stage1_async(
+        cls,
+        *,
+        train_data: Rows,
+        test_data: Optional[Rows] = None,
+        valid_data: Optional[Rows] = None,
+        sequence_col: str = "sequence",
+        lr: float = 1e-4,
+        batch_size: int = 8,
+        grad_accum: int = 16,
+        max_steps: int = 50000,
+        max_length: int = 2048,
+        save_every: int = 1000,
+        fp16: bool = False,
+        run_name: Optional[str] = None,
+        environment_id: Optional[Union[int, str]] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> dict:
+        """Launch DSM Stage 1 (single-chain masked-LM finetune)."""
+        payload = _drop_none(
+            {
+                "run_name": run_name,
+                "sequence_col": sequence_col,
+                "train_data": train_data,
+                "test_data": test_data,
+                "valid_data": valid_data,
+                "lr": lr,
+                "batch_size": batch_size,
+                "grad_accum": grad_accum,
+                "max_steps": max_steps,
+                "max_length": max_length,
+                "save_every": save_every,
+                "fp16": fp16,
+                "environment_id": environment_id,
+            }
+        )
+        return await _post(
+            "dsm/stage1/runs/", payload, api_key, base_url, "create DSM Stage 1 run"
+        )
+
+    @classmethod
+    def dsm_stage1(cls, **kwargs) -> dict:
+        """Synchronous wrapper for :meth:`dsm_stage1_async`."""
+        return _run_sync(cls.dsm_stage1_async(**kwargs))
+
+    # -- DSM Stage 2 ------------------------------------------------------
+
+    @classmethod
+    async def dsm_stage2_async(
+        cls,
+        *,
+        stage1_checkpoint: str,
+        paired_data: Rows,
+        unpaired_data: Optional[Rows] = None,
+        heavy_col: str = "heavy",
+        light_col: str = "light",
+        use_mixed_training: bool = False,
+        fp16: bool = False,
+        lr: float = 5e-5,
+        batch_size: int = 4,
+        unpaired_batch_size: int = 8,
+        grad_accum: int = 16,
+        max_steps: int = 25000,
+        max_length: int = 300,
+        unpaired_ratio: float = 2.0,
+        run_name: Optional[str] = None,
+        environment_id: Optional[Union[int, str]] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> dict:
+        """Launch DSM Stage 2 (paired multichain finetune from a Stage 1 checkpoint)."""
+        payload = _drop_none(
+            {
+                "run_name": run_name,
+                "stage1_checkpoint": stage1_checkpoint,
+                "paired_data": paired_data,
+                "unpaired_data": unpaired_data,
+                "heavy_col": heavy_col,
+                "light_col": light_col,
+                "use_mixed_training": use_mixed_training,
+                "fp16": fp16,
+                "lr": lr,
+                "batch_size": batch_size,
+                "unpaired_batch_size": unpaired_batch_size,
+                "grad_accum": grad_accum,
+                "max_steps": max_steps,
+                "max_length": max_length,
+                "unpaired_ratio": unpaired_ratio,
+                "environment_id": environment_id,
+            }
+        )
+        return await _post(
+            "dsm/stage2/runs/", payload, api_key, base_url, "create DSM Stage 2 run"
+        )
+
+    @classmethod
+    def dsm_stage2(cls, **kwargs) -> dict:
+        """Synchronous wrapper for :meth:`dsm_stage2_async`."""
+        return _run_sync(cls.dsm_stage2_async(**kwargs))
+
+    # -- DSM RL -----------------------------------------------------------
+
+    @classmethod
+    async def dsm_rl_async(
+        cls,
+        *,
+        seed_sequences: Union[List[str], str],
+        oracle_type: str = "esmc",
+        stability_objective: str = "thermostability",
+        training_mode: str = "online",
+        algorithm: str = "ppo",
+        num_episodes: int = 100,
+        samples_per_episode: int = 64,
+        learning_rate: float = 3e-4,
+        batch_size: int = 8,
+        mask_ratio: float = 0.3,
+        mutation_rate: float = 0.1,
+        run_name: Optional[str] = None,
+        environment_id: Optional[Union[int, str]] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> dict:
+        """Launch DSM RL protein optimization against an oracle."""
+        payload = _drop_none(
+            {
+                "run_name": run_name,
+                "seed_sequences": seed_sequences,
+                "oracle_type": oracle_type,
+                "stability_objective": stability_objective,
+                "training_mode": training_mode,
+                "algorithm": algorithm,
+                "num_episodes": num_episodes,
+                "samples_per_episode": samples_per_episode,
+                "learning_rate": learning_rate,
+                "batch_size": batch_size,
+                "mask_ratio": mask_ratio,
+                "mutation_rate": mutation_rate,
+                "environment_id": environment_id,
+            }
+        )
+        return await _post("dsm/rl/runs/", payload, api_key, base_url, "create DSM RL run")
+
+    @classmethod
+    def dsm_rl(cls, **kwargs) -> dict:
+        """Synchronous wrapper for :meth:`dsm_rl_async`."""
+        return _run_sync(cls.dsm_rl_async(**kwargs))
+
+    # -- Run tracking -----------------------------------------------------
+
+    @classmethod
+    async def list_runs_async(
+        cls,
+        *,
+        dag: Optional[str] = None,
+        status: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 20,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> dict:
+        """List the caller's finetune runs (paginated)."""
+        params = []
+        if dag:
+            params.append(f"dag={dag}")
+        if status:
+            params.append(f"status={status}")
+        params.append(f"page={page}")
+        params.append(f"page_size={page_size}")
+        endpoint = "runs/?" + "&".join(params)
+        return await _get(endpoint, api_key, base_url, "list runs")
+
+    @classmethod
+    def list_runs(cls, **kwargs) -> dict:
+        """Synchronous wrapper for :meth:`list_runs_async`."""
+        return _run_sync(cls.list_runs_async(**kwargs))
+
+    @classmethod
+    async def get_run_async(
+        cls, run_id: str, *, api_key: Optional[str] = None, base_url: Optional[str] = None
+    ) -> dict:
+        """Fetch sanitized detail (status, results) for a single run."""
+        return await _get(f"runs/{run_id}/", api_key, base_url, "get run")
+
+    @classmethod
+    def get_run(cls, run_id: str, **kwargs) -> dict:
+        """Synchronous wrapper for :meth:`get_run_async`."""
+        return _run_sync(cls.get_run_async(run_id, **kwargs))
+
+    @classmethod
+    async def progress_async(
+        cls, run_id: str, *, api_key: Optional[str] = None, base_url: Optional[str] = None
+    ) -> dict:
+        """Fetch lightweight status + telemetry channel id for a run.
+
+        For live updates, subscribe to the returned ``channel_id`` over the
+        platform WebSocket rather than polling this endpoint in a tight loop.
+        """
+        return await _get(f"runs/{run_id}/progress/", api_key, base_url, "get progress")
+
+    @classmethod
+    def progress(cls, run_id: str, **kwargs) -> dict:
+        """Synchronous wrapper for :meth:`progress_async`."""
+        return _run_sync(cls.progress_async(run_id, **kwargs))
+
+    @classmethod
+    async def cancel_async(
+        cls, run_id: str, *, api_key: Optional[str] = None, base_url: Optional[str] = None
+    ) -> dict:
+        """Cancel an in-flight run."""
+        return await _delete(f"runs/{run_id}/", api_key, base_url, "cancel run")
+
+    @classmethod
+    def cancel(cls, run_id: str, **kwargs) -> dict:
+        """Synchronous wrapper for :meth:`cancel_async`."""
+        return _run_sync(cls.cancel_async(run_id, **kwargs))
+
+    @classmethod
+    def wait(
+        cls,
+        run_id: str,
+        *,
+        poll_interval: float = 15.0,
+        timeout: Optional[float] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> dict:
+        """Block until *run_id* reaches a terminal state, returning its detail.
+
+        Convenience for scripts. Polls :meth:`progress`; for low-latency
+        updates use the telemetry WebSocket channel instead.
+
+        Args:
+            poll_interval: Seconds between status checks.
+            timeout: Max seconds to wait (``None`` = no limit).
+
+        Raises:
+            TimeoutError: If *timeout* elapses before the run finishes.
+        """
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            prog = cls.progress(run_id, api_key=api_key, base_url=base_url)
+            if str(prog.get("status", "")).lower() in TERMINAL_STATUSES:
+                return cls.get_run(run_id, api_key=api_key, base_url=base_url)
+            if deadline is not None and time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Run {run_id} did not finish within {timeout}s "
+                    f"(last status: {prog.get('status')})."
+                )
+            time.sleep(poll_interval)

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -1,0 +1,181 @@
+"""Unit tests for the Finetune SDK client.
+
+These tests exercise payload construction, endpoint routing, error mapping, and
+the wait() polling loop without any network access — the async HTTP helpers are
+monkeypatched to capture calls. (Live behavior is covered by the biolm_web API
+tests against the Modal QA deploys.)
+"""
+from types import SimpleNamespace
+
+import pytest
+
+import biolmai.finetune as ft
+from biolmai import Finetune
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Capture calls to the module-level HTTP helpers; return canned responses."""
+    calls = []
+
+    async def fake_post(endpoint, payload, api_key, base_url, action):
+        calls.append(("POST", endpoint, payload))
+        return {"run_id": "ALY_test", "dag": "x", "status": "scheduled"}
+
+    async def fake_get(endpoint, api_key, base_url, action):
+        calls.append(("GET", endpoint, None))
+        return {"run_id": "ALY_test", "status": "scheduled"}
+
+    async def fake_delete(endpoint, api_key, base_url, action):
+        calls.append(("DELETE", endpoint, None))
+        return {"run_id": "ALY_test", "status": "cancelled"}
+
+    monkeypatch.setattr(ft, "_post", fake_post)
+    monkeypatch.setattr(ft, "_get", fake_get)
+    monkeypatch.setattr(ft, "_delete", fake_delete)
+    return calls
+
+
+# -- endpoint routing -------------------------------------------------------
+
+
+def test_xgboost_routes_and_builds_payload(captured):
+    Finetune.xgboost(
+        train_data=[{"sequence": "EVQLVESGGG", "label": 0}],
+        embedding_models=["esm2-8m"],
+        task_type="classification",
+        hyperopt=True,
+        hyperopt_n_trials=10,
+    )
+    method, endpoint, payload = captured[0]
+    assert (method, endpoint) == ("POST", "xgboost/runs/")
+    assert payload["embedding_models"] == ["esm2-8m"]
+    assert payload["hyperopt"] is True
+    assert payload["hyperopt_n_trials"] == 10
+    assert payload["train_data"] == [{"sequence": "EVQLVESGGG", "label": 0}]
+
+
+def test_dsm_stage1_routes(captured):
+    Finetune.dsm_stage1(train_data=[{"sequence": "AAA"}], max_steps=5)
+    method, endpoint, payload = captured[0]
+    assert (method, endpoint) == ("POST", "dsm/stage1/runs/")
+    assert payload["max_steps"] == 5
+    assert payload["sequence_col"] == "sequence"
+
+
+def test_dsm_stage2_routes(captured):
+    Finetune.dsm_stage2(
+        stage1_checkpoint="finetune/dsm-mab/u/1/ckpt",
+        paired_data=[{"heavy": "AAA", "light": "BBB"}],
+    )
+    method, endpoint, payload = captured[0]
+    assert (method, endpoint) == ("POST", "dsm/stage2/runs/")
+    assert payload["stage1_checkpoint"] == "finetune/dsm-mab/u/1/ckpt"
+    assert payload["heavy_col"] == "heavy"
+
+
+def test_dsm_rl_routes(captured):
+    Finetune.dsm_rl(seed_sequences=["EVQLVESGGG"], num_episodes=2, oracle_type="esmc")
+    method, endpoint, payload = captured[0]
+    assert (method, endpoint) == ("POST", "dsm/rl/runs/")
+    assert payload["seed_sequences"] == ["EVQLVESGGG"]
+    assert payload["num_episodes"] == 2
+
+
+def test_get_progress_cancel_routes(captured):
+    Finetune.get_run("ALY_1")
+    Finetune.progress("ALY_1")
+    Finetune.cancel("ALY_1")
+    assert captured[0] == ("GET", "runs/ALY_1/", None)
+    assert captured[1] == ("GET", "runs/ALY_1/progress/", None)
+    assert captured[2] == ("DELETE", "runs/ALY_1/", None)
+
+
+def test_list_runs_query_params(captured):
+    Finetune.list_runs(dag="finetune_xgboost", status="running", page=2, page_size=50)
+    method, endpoint, _ = captured[0]
+    assert method == "GET"
+    assert endpoint.startswith("runs/?")
+    assert "dag=finetune_xgboost" in endpoint
+    assert "status=running" in endpoint
+    assert "page=2" in endpoint
+    assert "page_size=50" in endpoint
+
+
+# -- payload hygiene --------------------------------------------------------
+
+
+def test_drop_none_omits_unset_optionals(captured):
+    # environment_id / test_data left unset → must not appear in payload so the
+    # server applies its own defaults.
+    Finetune.xgboost(train_data=[{"sequence": "A", "label": 1}], embedding_models=["esm2-8m"])
+    _, _, payload = captured[0]
+    assert "environment_id" not in payload
+    assert "test_data" not in payload
+    assert "validation_data" not in payload
+
+
+def test_drop_none_helper():
+    assert ft._drop_none({"a": 1, "b": None, "c": 0}) == {"a": 1, "c": 0}
+
+
+# -- error mapping ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "code,exc",
+    [
+        (401, PermissionError),
+        (402, PermissionError),
+        (404, FileNotFoundError),
+        (400, ValueError),
+        (500, ValueError),
+    ],
+)
+def test_raise_for_status_maps_errors(code, exc):
+    resp = SimpleNamespace(
+        status_code=code,
+        text="boom",
+        json=lambda: {"error": "boom"},
+    )
+    with pytest.raises(exc):
+        ft._raise_for_status(resp, "do thing")
+
+
+def test_raise_for_status_ok_passes():
+    resp = SimpleNamespace(status_code=201, text="", json=lambda: {})
+    assert ft._raise_for_status(resp, "do thing") is None
+
+
+# -- wait() polling ---------------------------------------------------------
+
+
+def test_wait_returns_detail_when_terminal(monkeypatch):
+    statuses = iter(["running", "running", "succeeded"])
+
+    monkeypatch.setattr(
+        Finetune, "progress", classmethod(lambda cls, rid, **kw: {"status": next(statuses)})
+    )
+    monkeypatch.setattr(
+        Finetune,
+        "get_run",
+        classmethod(lambda cls, rid, **kw: {"run_id": rid, "status": "succeeded", "results": {}}),
+    )
+    monkeypatch.setattr(ft.time, "sleep", lambda *_: None)
+
+    out = Finetune.wait("ALY_1", poll_interval=0)
+    assert out["status"] == "succeeded"
+    assert out["run_id"] == "ALY_1"
+
+
+def test_wait_times_out(monkeypatch):
+    monkeypatch.setattr(
+        Finetune, "progress", classmethod(lambda cls, rid, **kw: {"status": "running"})
+    )
+    monkeypatch.setattr(ft.time, "sleep", lambda *_: None)
+    # monotonic jumps past the deadline on the second read.
+    ticks = iter([0.0, 0.0, 100.0])
+    monkeypatch.setattr(ft.time, "monotonic", lambda: next(ticks))
+
+    with pytest.raises(TimeoutError):
+        Finetune.wait("ALY_1", poll_interval=0, timeout=10)


### PR DESCRIPTION
## Summary

Adds `biolmai.Finetune` — a Python client for finetuning workflows. Lets users launch and track **XGBoost** and **DSM** (Stage 1, Stage 2, RL) finetuning runs from Python with the SDK's standard token/cookie auth, no browser console required.

## API

```python
from biolmai import Finetune

# XGBoost finetune with hyperopt
run = Finetune.xgboost(
    train_data=[{"sequence": "EVQLVESGGG", "label": 0},
                {"sequence": "QVQLVQSGAE", "label": 1}],
    embedding_models=["esm2-8m"],
    task_type="classification",
    hyperopt=True, hyperopt_n_trials=20,
)

# DSM stages + RL
Finetune.dsm_stage1(train_data=[...], max_steps=50000)
Finetune.dsm_stage2(stage1_checkpoint="...", paired_data=[...])
Finetune.dsm_rl(seed_sequences=["EVQL..."], oracle_type="esmc", num_episodes=100)

# track / cancel
Finetune.list_runs(status="running")
Finetune.progress(run["run_id"])        # status + telemetry channel id
detail = Finetune.wait(run["run_id"])   # block until terminal, return results
Finetune.cancel(run["run_id"])
```

Every method has an `*_async` counterpart; the sync wrappers reuse the
`protocols.py` event-loop-safe runner so they work in scripts, notebooks, and async code.

## Design

- **Mirrors `biolmai/protocols.py`**: same `HttpClient` + `CredentialsProvider` auth (`api_key=` / `BIOLMAI_TOKEN` / `BIOLM_TOKEN` / credentials file), same async-with-sync-wrapper shape, same error mapping (401→`PermissionError`, 404→`FileNotFoundError`, 4xx/5xx→`ValueError`; plus 402→`PermissionError` for ungated accounts).
- **Inline data** (`train_data`, `paired_data`, …) accepts a list of row dicts or a CSV string, sent as JSON.
- **`None` optionals are dropped** from the payload so server-side defaults apply; only what the caller sets is transmitted.
- **`wait()`** is a convenience poller; the telemetry WebSocket channel is the low-latency path for live updates.

## Testing

16 unit tests (`tests/test_finetune.py`), no network — the async HTTP helpers are monkeypatched to capture calls:
- endpoint routing for all four create methods + list/get/progress/cancel
- query-param assembly for `list_runs`
- payload hygiene (`None` optionals omitted)
- error-code → exception mapping (401/402/404/400/500)
- `wait()` terminal-state return and timeout

```
16 passed in 3.52s
```

`ruff check` clean; `import biolmai` clean with `Finetune` exported in `__all__`.