### PR TITLE
chore: fix PSR config and bump to 0.5.0

### DIFF
--- a/biolmai/__init__.py
+++ b/biolmai/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for BioLM AI."""
 __author__ = """Nikhil Haas"""
 __email__ = "nikhil@biolm.ai"
-__version__ = '0.4.1'
+__version__ = '0.5.0'
 
 from biolmai.core.http import BioLMApi, BioLMApiClient
 from biolmai.biolmai import BioLM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 [project]
 name = "biolmai"
-version = "0.4.0"
+version = "0.5.0"
 description = "BioLM Python client"
 authors = [
     { name="BioLM", email="support@biolm.ai" }
@@ -123,7 +123,7 @@ pipeline = [
 [tool.semantic_release]
 version_variables = ["biolmai/__init__.py:__version__"]
 version_toml = ["pyproject.toml:project.version"]
-commit_message = "chore(release): {version} [skip ci]\n\n{changelog}"
+commit_message = "chore(release): {version} [skip ci]"
 tag_format = "v{version}"
 upload_to_pypi = false
 upload_to_vcs_release = true


### PR DESCRIPTION
## Summary

Two fixes for the automated versioning workflow:

**PSR commit_message template fix:**
`{changelog}` is not a valid template variable in python-semantic-release v9 (it was v8). Removed it from `commit_message` to fix the `KeyError: 'changelog'` that was crashing the `version` job on every main push.

**Version bump to 0.5.0:**
PSR failed before it could commit the version bump. Manually landing `0.5.0` to reflect the three feature releases merged since `v0.4.0` (pipeline design primitives, finetune SDK, ProtocolClient), and tagging `v0.5.0` so PSR has a clean baseline for future runs.

After this merges the `version` job on main should work correctly for all subsequent `feat:` and `fix:` commits.